### PR TITLE
Fix FFmpeg tonemap filter graph

### DIFF
--- a/luxury_video_master_grader.py
+++ b/luxury_video_master_grader.py
@@ -496,21 +496,25 @@ def build_filter_graph(config: Dict[str, object]) -> Tuple[str, str]:
 
     tone_map = config.get("tone_map")
     if tone_map and str(tone_map).lower() != "off":
-        tm_args = [
+        zscale_args = [
             "primaries=bt709",
             "transfer=bt709",
             "matrix=bt709",
             "range=tv",
-            f"tonemap={tone_map}",
         ]
+        new_label = next_label()
+        nodes.append(f"[{current}]zscale={':'.join(zscale_args)}[{new_label}]")
+        current = new_label
+
+        tonemap_args = [f"tonemap={tone_map}"]
         tone_map_peak = config.get("tone_map_peak")
         if tone_map_peak is not None:
-            tm_args.append(f"tonemap_param={float(tone_map_peak):.4f}")
+            tonemap_args.append(f"peak={float(tone_map_peak):.4f}")
         tone_map_desat = config.get("tone_map_desat")
         if tone_map_desat is not None:
-            tm_args.append(f"tonemap_desat={float(tone_map_desat):.4f}")
+            tonemap_args.append(f"desat={float(tone_map_desat):.4f}")
         new_label = next_label()
-        nodes.append(f"[{current}]zscale={':'.join(tm_args)}[{new_label}]")
+        nodes.append(f"[{current}]tonemap={':'.join(tonemap_args)}[{new_label}]")
         current = new_label
 
     denoise = config.get("denoise")

--- a/tests/test_luxury_video_master_grader.py
+++ b/tests/test_luxury_video_master_grader.py
@@ -120,7 +120,10 @@ def test_build_filter_graph_includes_optional_nodes(tmp_path):
     assert "blend=all_expr='A*(1-0.6000)+B*0.6000'" in graph
     assert "unsharp=luma_msize_x=7" in graph
     assert "noise=alls=3.50:allf=t+u" in graph
-    assert "zscale=primaries=bt709:transfer=bt709:matrix=bt709:range=tv:tonemap=hable:tonemap_param=1200.0000:tonemap_desat=0.2500" in graph
+    assert "zscale=primaries=bt709:transfer=bt709:matrix=bt709:range=tv" in graph
+    assert "tonemap=tonemap=hable:peak=1200.0000:desat=0.2500" in graph
+    assert "tonemap_desat=" not in graph
+    assert "tonemap_param=" not in graph
     assert "gradfun=strength=0.70:radius=16" in graph
     assert "gblur=sigma=20.0000" in graph
     assert "blend=all_mode='screen':all_opacity=0.4000" in graph


### PR DESCRIPTION
## Summary
- update the tone-mapping stage to keep the zscale colour conversion but run a dedicated tonemap filter with supported options
- refresh the optional-node test expectations to match the new filter graph and guard against unsupported tonemap options

## Testing
- pytest tests/test_luxury_video_master_grader.py

------
https://chatgpt.com/codex/tasks/task_e_68d6c59491dc832ab3f9d0043c2d353f