### PR TITLE
Skip TIFF batch tests when NumPy is unavailable

### DIFF
--- a/tests/test_luxury_tiff_batch_processor.py
+++ b/tests/test_luxury_tiff_batch_processor.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from pathlib import Path
 import sys
 
-import numpy as np
-from PIL import Image, TiffImagePlugin
 import pytest
+np = pytest.importorskip("numpy")
+from PIL import Image, TiffImagePlugin
 
 sys.path.append(str(Path(__file__).resolve().parent.parent))
 


### PR DESCRIPTION
## Summary
- use pytest.importorskip to ensure the luxury TIFF batch tests skip when NumPy is missing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6c7845da0832aa4c3344cf20af42b