### PR TITLE
Fix syntax artifacts in color tag summary

### DIFF
--- a/luxury_video_master_grader.py
+++ b/luxury_video_master_grader.py
@@ -247,24 +247,10 @@ def summarize_probe(data: Dict[str, object]) -> str:
                 video_info += " 16bit"
 
         # Add color metadata if present
-        def normalize_color_tag(value: Optional[str]) -> Optional[str]:
-            if value is None:
-                return None
-            cleaned = value.strip().lower()
-            if cleaned in {"", "unknown", "unspecified"}:
-                return None
-            return cleaned
-
         color_parts = []
-        codex/fix-syntax-merge-conflicts-in-code
-        color_primaries = normalize_color_tag(video.get("color_primaries"))
-        color_trc = normalize_color_tag(video.get("color_trc"))
-        colorspace = normalize_color_tag(video.get("colorspace"))
-
         color_primaries = normalise_color_tag(video.get("color_primaries"))
         color_trc = normalise_color_tag(video.get("color_trc"))
         colorspace = normalise_color_tag(video.get("colorspace"))
-        main
 
         if color_primaries:
             color_parts.append(f"primaries={color_primaries}")


### PR DESCRIPTION
## Summary
- remove stray merge-conflict lines in the video stream summary helper
- reuse the shared color tag normalisation helper when adding color metadata

## Testing
- flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics *(fails: flake8 not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d721d61a34832a91291844977e5dad