### PR TITLE
Fix summarize_probe merge conflict artifacts

### DIFF
--- a/luxury_video_master_grader.py
+++ b/luxury_video_master_grader.py
@@ -247,24 +247,10 @@ def summarize_probe(data: Dict[str, object]) -> str:
                 video_info += " 16bit"
 
         # Add color metadata if present
-        def normalize_color_tag(value: Optional[str]) -> Optional[str]:
-            if value is None:
-                return None
-            cleaned = value.strip().lower()
-            if cleaned in {"", "unknown", "unspecified"}:
-                return None
-            return cleaned
-
         color_parts = []
-        codex/fix-syntax-merge-conflicts-in-code
-        color_primaries = normalize_color_tag(video.get("color_primaries"))
-        color_trc = normalize_color_tag(video.get("color_trc"))
-        colorspace = normalize_color_tag(video.get("colorspace"))
-
         color_primaries = normalise_color_tag(video.get("color_primaries"))
         color_trc = normalise_color_tag(video.get("color_trc"))
         colorspace = normalise_color_tag(video.get("colorspace"))
-        main
 
         if color_primaries:
             color_parts.append(f"primaries={color_primaries}")


### PR DESCRIPTION
## Summary
- remove merge-conflict markers from the summarize_probe color metadata block
- rely on the shared normalise_color_tag helper when describing color metadata

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d722560558832a8e19864fed46f3c5