### PR TITLE
Clean up color metadata normalization in summarize_probe

### DIFF
--- a/luxury_video_master_grader.py
+++ b/luxury_video_master_grader.py
@@ -248,15 +248,9 @@ def summarize_probe(data: Dict[str, object]) -> str:
 
         # Add color metadata if present
         color_parts = []
-        copilot/fix-acc44894-7440-470d-87ee-38faaa084415
-        color_primaries = normalize_color_tag(video.get("color_primaries"))
-        color_trc = normalize_color_tag(video.get("color_trc"))
-        colorspace = normalize_color_tag(video.get("colorspace"))
-
         color_primaries = normalise_color_tag(video.get("color_primaries"))
         color_trc = normalise_color_tag(video.get("color_trc"))
         colorspace = normalise_color_tag(video.get("colorspace"))
-        main
 
         if color_primaries:
             color_parts.append(f"primaries={color_primaries}")


### PR DESCRIPTION
## Summary
- remove merge artifacts from the summarize_probe color metadata block
- consistently call the normalise_color_tag helper for primaries, transfer, and colorspace tags

## Testing
- pytest tests/test_luxury_video_master_grader.py::test_summarize_probe_ignores_non_descriptive_color_tags

------
https://chatgpt.com/codex/tasks/task_e_68d727d400a0832aa269b8c26e1208f2