### PR TITLE
Fix README conflict by documenting HDR pipeline highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,15 @@ so the tool can apply tasteful tone mapping automatically, or respect explicit
 ## HDR Production Pipeline
 
 `hdr_production_pipeline.sh` orchestrates a full HDR finishing pass, combining ACES
-tonemapping, adaptive debanding, and filmic halation for gallery-ready masters.
+tonemapping, adaptive debanding, and filmic halation for gallery-ready masters. The
+script mirrors the conflict resolution between the Codex automation branch and the main
+documentation thread by retaining the bespoke HDR steps alongside the broader pipeline
+overview introduced on main.
+
+### Highlights
+- ACES output transform selection with Dolby Vision and HDR10 metadata preservation
+- Adaptive debanding tuned to Codex reference recipes
+- Filmic halation and finishing touches that complement the luxury master grader
 
 ### Requirements
 - macOS or Linux shell environment


### PR DESCRIPTION
## Summary
- reconcile the README HDR pipeline section so the Codex conflict resolution context is preserved
- document key highlights for the hdr_production_pipeline.sh workflow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d72d454b64832ab6bb25fa0365ef6a