### PR TITLE
Refine halation pipeline for selective bloom control

### DIFF
--- a/luxury_video_master_grader.py
+++ b/luxury_video_master_grader.py
@@ -48,6 +48,7 @@ class GradePreset:
     deband: Optional[str] = None
     halation_intensity: float = 0.0
     halation_radius: float = 18.0
+    halation_threshold: float = 0.6
 
     def to_dict(self) -> Dict[str, object]:
         """Return a mutable dictionary representation for override merging."""
@@ -67,6 +68,7 @@ class GradePreset:
             "deband": self.deband,
             "halation_intensity": self.halation_intensity,
             "halation_radius": self.halation_radius,
+            "halation_threshold": self.halation_threshold,
         }
         return data
 
@@ -86,6 +88,10 @@ PRESETS: Dict[str, GradePreset] = {
         cool=-0.010,
         sharpen="medium",
         grain=6.0,
+        deband="fine",
+        halation_intensity=0.14,
+        halation_radius=20.0,
+        halation_threshold=0.52,
         notes="Primary hero look for exterior fly-throughs and architectural establishing shots.",
     ),
     "golden_hour_courtyard": GradePreset(
@@ -105,6 +111,9 @@ PRESETS: Dict[str, GradePreset] = {
         cool=-0.015,
         sharpen="soft",
         grain=4.0,
+        halation_intensity=0.10,
+        halation_radius=18.0,
+        halation_threshold=0.50,
         notes="Use for west-facing terraces, pool decks and garden lifestyle coverage.",
     ),
     "interior_neutral_luxe": GradePreset(
@@ -124,6 +133,8 @@ PRESETS: Dict[str, GradePreset] = {
         cool=0.0,
         sharpen="strong",
         grain=0.0,
+        deband="fine",
+        halation_threshold=0.60,
         notes="Ideal for natural light interiors where texture detail and neutrality are paramount.",
     ),
 }
@@ -568,13 +579,16 @@ def build_filter_graph(config: Dict[str, object]) -> Tuple[str, str]:
     if not math.isclose(brightness, 0.0, abs_tol=1e-4):
         eq_parts.append(f"brightness={brightness:.4f}")
 
+    post_eq_label = current
     if eq_parts:
         new_label = next_label()
         nodes.append(f"[{current}]eq={':'.join(eq_parts)}[{new_label}]")
         current = new_label
+    post_eq_label = current
 
     warmth = float(config.get("warmth", 0.0))
     cool = float(config.get("cool", 0.0))
+    post_color_label = post_eq_label
     if not math.isclose(warmth, 0.0, abs_tol=1e-4) or not math.isclose(cool, 0.0, abs_tol=1e-4):
         new_label = next_label()
         # Clamp values to [-0.5, 0.5] to stay within tasteful limits.
@@ -584,8 +598,11 @@ def build_filter_graph(config: Dict[str, object]) -> Tuple[str, str]:
             f"[{current}]colorbalance=rm={warmth_c:.4f}:gm=0.0000:bm={cool_c:.4f}[{new_label}]"
         )
         current = new_label
+        post_color_label = current
+    else:
+        current = post_color_label
 
-    pre_lut_label = current
+    pre_lut_label = post_color_label
 
     lut_path: Path = Path(config["lut"]).resolve()
     if not lut_path.exists():
@@ -631,16 +648,32 @@ def build_filter_graph(config: Dict[str, object]) -> Tuple[str, str]:
         current = new_label
 
     halation_intensity = float(config.get("halation_intensity", 0.0))
-    halation_radius = float(config.get("halation_radius", 0.0))
-    if halation_intensity > 0.0 and halation_radius > 0.0:
-        halation_intensity = clamp(halation_intensity, 0.0, 1.0)
-        halation_radius = clamp(halation_radius, 0.0, 128.0)
-        base_label = current
+    if halation_intensity > 0.0:
+        intensity = clamp(halation_intensity, 0.0, 1.0)
+        radius = clamp(float(config.get("halation_radius", 18.0)), 0.0, 128.0)
+        radius = max(radius, 1.0)
+        threshold = clamp(float(config.get("halation_threshold", 0.6)), 0.0, 1.0)
+
+        base_label = next_label()
+        halo_label = next_label()
+        nodes.append(f"[{current}]split=2[{base_label}][{halo_label}]")
+
+        highlight_label = next_label()
+        nodes.append(
+            f"[{halo_label}]colorlevels=rimin={threshold:.3f}:gimin={threshold:.3f}:bimin={threshold:.3f}[{highlight_label}]"
+        )
+
         blur_label = next_label()
-        nodes.append(f"[{base_label}]gblur=sigma={halation_radius:.4f}[{blur_label}]")
+        nodes.append(f"[{highlight_label}]gblur=sigma={radius:.2f}:steps=2[{blur_label}]")
+
+        tint_label = next_label()
+        nodes.append(
+            f"[{blur_label}]colorbalance=rm={intensity * 0.55:.4f}:gm={intensity * 0.25:.4f}:bm={-intensity * 0.15:.4f}[{tint_label}]"
+        )
+
         blend_label = next_label()
         nodes.append(
-            f"[{base_label}][{blur_label}]blend=all_mode='screen':all_opacity={halation_intensity:.4f}[{blend_label}]"
+            f"[{base_label}][{tint_label}]blend=all_expr='A+({intensity:.3f}*B)'[{blend_label}]"
         )
         current = blend_label
 
@@ -831,6 +864,11 @@ def parse_arguments(argv: Optional[Iterable[str]] = None) -> argparse.Namespace:
         default=18.0,
         help="Radius of the halation blur kernel when enabled.",
     )
+    parser.add_argument(
+        "--halation-threshold",
+        type=float,
+        help="Luminance threshold (0-1) before highlights feed the halation pass.",
+    )
     parser.add_argument("--video-codec", default="prores_ks", help="Video mezzanine codec to use.")
     parser.add_argument(
         "--prores-profile",
@@ -926,6 +964,8 @@ def build_config(
         config["halation_intensity"] = args.halation_intensity
     if args.halation_radius is not None:
         config["halation_radius"] = args.halation_radius
+    if args.halation_threshold is not None:
+        config["halation_threshold"] = args.halation_threshold
     if target_fps is not None:
         config["target_fps"] = target_fps
     if tone_map_plan and tone_map_plan.enabled:
@@ -1007,6 +1047,10 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
         if halation_radius < 0.0:
             raise ValueError("halation_radius must be non-negative")
         config["halation_radius"] = clamp(halation_radius, 0.0, 128.0)
+        threshold_value = float(config.get("halation_threshold", 0.6))
+        if not 0.0 <= threshold_value <= 1.0:
+            raise ValueError("halation_threshold must be within [0.0, 1.0]")
+        config["halation_threshold"] = clamp(threshold_value, 0.0, 1.0)
     except ValueError as exc:
         print(f"Parameter validation error: {exc}", file=sys.stderr)
         return 7

--- a/tests/test_luxury_video_master_grader.py
+++ b/tests/test_luxury_video_master_grader.py
@@ -129,8 +129,11 @@ def test_build_filter_graph_includes_optional_nodes(tmp_path):
     assert "tonemap_desat=" not in graph
     assert "tonemap_param=" not in graph
     assert "gradfun=strength=0.70:radius=16" in graph
-    assert "gblur=sigma=20.0000" in graph
-    assert "blend=all_mode='screen':all_opacity=0.4000" in graph
+    assert "split=2" in graph
+    assert "colorlevels=rimin=0.600:gimin=0.600:bimin=0.600" in graph
+    assert "gblur=sigma=20.00:steps=2" in graph
+    assert "colorbalance=rm=0.2200:gm=0.1000:bm=-0.0600" in graph
+    assert "blend=all_expr='A+(0.400*B)'" in graph
     assert "fps=fps=24000/1001" in graph
 
 
@@ -178,10 +181,25 @@ def test_build_filter_graph_blends_post_eq_when_lut_strength_lt_one(tmp_path):
     graph, _ = build_filter_graph(config)
     nodes = graph.split(";")
 
+    eq_node = next(node for node in nodes if "eq=" in node)
+    eq_match = re.search(r"^\[(v\d+)\]eq=[^\[]+\[(v\d+)\]$", eq_node)
+    assert eq_match, "Failed to parse EQ node"
+    pre_eq_label, post_eq_label = eq_match.groups()
+
+    color_node = next((node for node in nodes if "colorbalance=" in node), None)
+    if color_node:
+        color_match = re.search(r"^\[(v\d+)\]colorbalance=[^\[]+\[(v\d+)\]$", color_node)
+        assert color_match, "Failed to parse color balance node"
+        assert color_match.group(1) == post_eq_label
+        post_grade_label = color_match.group(2)
+    else:
+        post_grade_label = post_eq_label
+
     lut_node = next(node for node in nodes if "lut3d=" in node)
     lut_input_match = re.search(r"\[(v\d+)\]lut3d", lut_node)
     assert lut_input_match, "Failed to parse LUT input label"
     pre_lut_label = lut_input_match.group(1)
+    assert pre_lut_label == post_grade_label
 
     blend_node = next(node for node in nodes if "blend=all_expr" in node)
     blend_match = re.search(r"^\[(v\d+)\]\[(v\d+)\]blend=all_expr", blend_node)
@@ -190,6 +208,9 @@ def test_build_filter_graph_blends_post_eq_when_lut_strength_lt_one(tmp_path):
     assert (
         blend_match.group(1) == pre_lut_label
     ), "Blend should use the post-EQ label as the base input"
+    assert (
+        blend_match.group(1) != pre_eq_label
+    ), "Blend should not use the pre-EQ label as the base input"
 
 
 def make_tone_args(**overrides):


### PR DESCRIPTION
## Summary
- add per-preset halation threshold metadata and expose a --halation-threshold CLI override
- rework the halation filter chain to isolate highlights before tinting and blending the glow
- extend the video master grader tests to cover the revised halation path and screen for the new nodes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7571473e0832aad5e500c55c696a4