### PR TITLE
Improve README structure and details

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,29 @@
 ## Overview
 A cutting-edge collection of **16 professional color grading LUTs** featuring innovative **Material Response** technology.
 
+## Table of Contents
+- [Collection Contents](#collection-contents)
+- [Innovation](#innovation)
+- [Usage](#usage)
+- [Luxury TIFF Batch Processor](#luxury-tiff-batch-processor)
+  - [Requirements](#requirements)
+  - [Example](#example)
+- [Luxury Video Master Grader](#luxury-video-master-grader)
+  - [Requirements](#requirements-1)
+  - [Examples](#examples)
+- [HDR Production Pipeline](#hdr-production-pipeline)
+  - [Highlights](#highlights)
+  - [Requirements](#requirements-2)
+  - [Example](#example-1)
+- [License](#license)
+
 ## Collection Contents
 - **Film Emulation**: Kodak 2393, FilmConvert Nitrate  
 - **Location Aesthetic**: Montecito Golden Hour, Spanish Colonial Warm  
 - **Material Response**: Revolutionary physics-based surface enhancement
 
 ## Innovation
-**Material Response LUTs** analyze and enhance how different surfaces interact with light—shifting from purely global color transforms to surface-aware rendering that respects highlights, midtones, and micro-contrast differently across materials.
+**Material Response LUTs** analyze and enhance how different surfaces interact with light—shifting from purely global color transforms to surface-aware rendering that respects highlights, midtones, and micro-contrast differently across materials. The approach keeps natural roll-off in highlights, protects nuanced midtone skin detail, and intelligently refines specular textures so metal, stone, glass, and fabric all retain their distinctive depth.
 
 ## Usage
 1. Import into DaVinci Resolve, Premiere Pro, or other color-grading software.
@@ -17,11 +33,14 @@ A cutting-edge collection of **16 professional color grading LUTs** featuring in
 3. Stack multiple LUTs for complex material interactions.
 
 ## Luxury TIFF Batch Processor
-The repository now includes `luxury_tiff_batch_processor.py`, a high-end batch workflow
-for polishing large-format TIFF photography prior to digital launch. The script preserves
-metadata, honors 16-bit source files when [`tifffile`](https://pypi.org/project/tifffile/)
-is available, and layers tonal, chroma, clarity, and diffusion refinements tuned for
-ultra-luxury real-estate storytelling.
+The repository now includes `luxury_tiff_batch_processor.py`, a high-end batch workflow for polishing large-format TIFF photography prior to digital launch. The script preserves metadata, honors 16-bit source files when [`tifffile`](https://pypi.org/project/tifffile/) is available, and layers tonal, chroma, clarity, and diffusion refinements tuned for ultra-luxury real-estate storytelling.
+
+### Key Features
+- Automatically reads and writes IPTC/XMP metadata so campaign details remain intact across exports.
+- Maintains 16-bit precision whenever the optional `tifffile` dependency is installed and falls back to Pillow for 8-bit output.
+- Offers presets that mirror the LUT families (Signature, Golden Hour, Heritage, etc.) for rapid client alignment.
+- Supports per-run overrides for exposure, midtone contrast, vibrance, clarity, glow, and more to accommodate creative direction.
+- Provides non-destructive previews with `--dry-run` and mirrors directory trees with `--recursive` for large productions.
 
 ### Requirements
 - Python 3.11+
@@ -43,12 +62,14 @@ plan without writing files, and `--recursive` to mirror nested shoot-day folders
 
 ## Luxury Video Master Grader
 
-`luxury_video_master_grader.py` brings the same curated aesthetic to short-form motion
-content. It wraps FFmpeg with preset-driven LUT application, tasteful denoising, clarity
-and film-grain treatments, then exports a mezzanine-ready Apple ProRes master by default.
-The pipeline now auto-detects HDR transfers and tone-maps them into a refined BT.709
-space, optionally adds ultra-fine debanding and cinematic halation bloom, and keeps
-gradient-rich interiors spotless with updated presets.
+`luxury_video_master_grader.py` brings the same curated aesthetic to short-form motion content. It wraps FFmpeg with preset-driven LUT application, tasteful denoising, clarity and film-grain treatments, then exports a mezzanine-ready Apple ProRes master by default. The pipeline now auto-detects HDR transfers and tone-maps them into a refined BT.709 space, optionally adds ultra-fine debanding and cinematic halation bloom, and keeps gradient-rich interiors spotless with updated presets.
+
+### Key Features
+- Intelligent source analysis that detects resolution, frame rate, HDR transfer characteristics, and audio layout before rendering.
+- Preset-driven workflows that blend LUT application with spatial/temporal filtering tailored to luxury real-estate cinematography.
+- Advanced finishing controls for debanding, halation, clarity, grain, and tone mapping to deliver cinematic masters out of the box.
+- Flexible output targets including mezzanine-grade ProRes profiles and user-defined frame rates via `--target-fps`.
+- Dry-run inspection that prints the underlying FFmpeg command for validation before committing to long renders.
 
 ### Requirements
 - FFmpeg 6+
@@ -75,29 +96,23 @@ python luxury_video_master_grader.py hdr.mov hdr_sdr_master.mov \
   --deband strong --halation-intensity 0.18 --halation-radius 22
 ```
 
-Use `--custom-lut` to feed bespoke `.cube` files, tweak parameters such as `--contrast`
-or `--grain`, layer in `--deband` smoothing or halation controls, and enable `--dry-run`
-to inspect the underlying FFmpeg command without rendering. The script automatically
-probes the source to surface resolution, frame-rate metadata and audio configuration
-before processing, then monitors for drift or variable frame-rate clips. When necessary
-it conforms delivery to the nearest cinema broadcast standard (or a user-specified
-`--target-fps`) to guarantee smooth, continuous playback. HDR clips are further analysed
-so the tool can apply tasteful tone mapping automatically, while explicit
-`--tone-map` overrides give you authoritative control whenever a specific operator is
-required.
+Use `--custom-lut` to feed bespoke `.cube` files, tweak parameters such as `--contrast` or `--grain`, layer in `--deband` smoothing or halation controls, and enable `--dry-run` to inspect the underlying FFmpeg command without rendering. The script automatically probes the source to surface resolution, frame-rate metadata and audio configuration before processing, then monitors for drift or variable frame-rate clips. When necessary it conforms delivery to the nearest cinema broadcast standard (or a user-specified `--target-fps`) to guarantee smooth, continuous playback. HDR clips are further analyzed so the tool can apply tasteful tone mapping automatically, while explicit `--tone-map` overrides give you authoritative control whenever a specific operator is required.
 
 ## HDR Production Pipeline
 
-`hdr_production_pipeline.sh` orchestrates a full HDR finishing pass, combining ACES
-tonemapping, adaptive debanding, and filmic halation for gallery-ready masters. The
-workflow harmonises the bespoke Codex automation steps with the broader pipeline
-overview introduced on main so teams can reference a single, unified set of HDR
-finishing instructions.
+`hdr_production_pipeline.sh` orchestrates a full HDR finishing pass, combining ACES tone mapping, adaptive debanding, and filmic halation for gallery-ready masters. The workflow harmonizes the bespoke Codex automation steps with the broader pipeline overview introduced on main so teams can reference a single, unified set of HDR finishing instructions.
+
+### Key Features
+- ACES Output Device Transform (ODT) selection, Dolby Vision metadata pass-through, and HDR10 mastering options for broadcast compliance.
+- Adaptive debanding tuned to Codex reference recipes to protect smooth gradients in modern architectural interiors.
+- Filmic halation and bloom controls that layer naturally over the LUT aesthetic without introducing color drift.
+- Optional tone-mapping operator selection (`--tone-map`) for precise control over HDR-to-SDR conversions.
+- Designed to slot after `luxury_video_master_grader.py` so teams can reuse LUT-driven looks while finishing in HDR.
 
 ### Highlights
-- ACES output transform selection with Dolby Vision and HDR10 metadata preservation
-- Adaptive debanding tuned to Codex reference recipes
-- Filmic halation and finishing touches that complement the luxury master grader
+- Consolidates automation steps from the Codex finishing toolkit into a single, reproducible command sequence.
+- Documents the hand-off from the LUT-driven grade to HDR-specific finishing so teams can collaborate without guesswork.
+- Provides defaults that mirror the examples in this README, making it simple to reproduce the reference masters.
 
 ### Requirements
 - macOS or Linux shell environment


### PR DESCRIPTION
## Summary
- add a table of contents and expanded Material Response description to the README
- highlight key features for the TIFF, video, and HDR tooling with clearer bullet lists
- update language for consistency and clarify highlights for the HDR production pipeline

## Testing
- not run (documentation only)

------
https://chatgpt.com/codex/tasks/task_e_68d8d61eabf8832a9b3fe326d4bebeff