### PR TITLE
Add test ensuring Lantern logo hover uses SVG gradient

### DIFF
--- a/tests/test_lantern_logo_css.py
+++ b/tests/test_lantern_logo_css.py
@@ -1,0 +1,52 @@
+"""Tests guarding Lantern logo CSS architectural decisions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+from typing import Callable, TypeVar
+
+ROOT = Path(__file__).resolve().parent.parent
+CSS_PATH = ROOT / "09_Client_Deliverables" / "Lantern_Logo_Implementation_Kit" / "lantern_logo.css"
+
+F = TypeVar("F", bound=Callable[..., object])
+
+
+def documents(note: str) -> Callable[[F], F]:
+    """Annotate a test with the documentation note it enforces."""
+
+    def decorator(func: F) -> F:
+        func.__doc__ = note if func.__doc__ is None else f"{note}\n{func.__doc__}"
+        return func
+
+    return decorator
+
+
+def _extract_hover_block(css: str) -> str:
+    pattern = (
+        r"@media\s*\(hover:\s*hover\)\s*and\s*\(pointer:\s*fine\)\s*\{\s*"
+        r"\.lantern-logo:hover\s+svg,\s*"
+        r"\.lantern-logo:focus-visible\s+svg\s*\{([^{}]+)\}\s*"
+        r"\}"
+    )
+    match = re.search(pattern, css, flags=re.S)
+    if not match:
+        raise AssertionError("Could not locate hover/focus block in Lantern logo CSS")
+    return match.group(1)
+
+
+def _extract_stroke_value(block: str) -> str:
+    stroke_match = re.search(r"stroke:\s*([^;]+);", block)
+    if not stroke_match:
+        raise AssertionError("Hover/focus block did not define a stroke declaration")
+    return stroke_match.group(1).strip()
+
+
+@documents("Logo uses SVG gradient on hover, not brand gradient")
+def test_hover_gradient_source() -> None:
+    css = CSS_PATH.read_text(encoding="utf-8")
+    hover_block = _extract_hover_block(css)
+    hover_stroke = _extract_stroke_value(hover_block)
+
+    assert hover_stroke == "url(#lantern-gradient)"
+    assert hover_stroke != "var(--brand-gradient)"


### PR DESCRIPTION
## Summary
- add a regression test for the Lantern logo CSS to confirm the hover/focus stroke pulls from the SVG gradient instead of the brand gradient token

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcd99d82a4832a8e2fff7125a1a8bc