### PR TITLE
Document architectural intent across tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,2 @@
+"""Test suite package initialization for architectural documentation decorators."""
+

--- a/tests/documentation.py
+++ b/tests/documentation.py
@@ -1,0 +1,21 @@
+"""Shared documentation helpers for architectural tests."""
+
+from __future__ import annotations
+
+from typing import Callable, TypeVar
+
+F = TypeVar("F", bound=Callable[..., object])
+
+
+def documents(note: str) -> Callable[[F], F]:
+    """Annotate a test with the documentation note it enforces."""
+
+    def decorator(func: F) -> F:
+        func.__doc__ = note if func.__doc__ is None else f"{note}\n{func.__doc__}"
+        return func
+
+    return decorator
+
+
+__all__ = ["documents"]
+

--- a/tests/test_lantern_logo_css.py
+++ b/tests/test_lantern_logo_css.py
@@ -4,22 +4,11 @@ from __future__ import annotations
 
 from pathlib import Path
 import re
-from typing import Callable, TypeVar
 
 ROOT = Path(__file__).resolve().parent.parent
 CSS_PATH = ROOT / "09_Client_Deliverables" / "Lantern_Logo_Implementation_Kit" / "lantern_logo.css"
 
-F = TypeVar("F", bound=Callable[..., object])
-
-
-def documents(note: str) -> Callable[[F], F]:
-    """Annotate a test with the documentation note it enforces."""
-
-    def decorator(func: F) -> F:
-        func.__doc__ = note if func.__doc__ is None else f"{note}\n{func.__doc__}"
-        return func
-
-    return decorator
+from .documentation import documents
 
 
 def _extract_hover_block(css: str) -> str:

--- a/tests/test_luxury_tiff_batch_processor.py
+++ b/tests/test_luxury_tiff_batch_processor.py
@@ -5,6 +5,8 @@ import sys
 
 import pytest
 
+from .documentation import documents
+
 np = pytest.importorskip("numpy")
 pytest.importorskip("PIL.Image")
 pytest.importorskip("PIL.TiffImagePlugin")
@@ -21,6 +23,7 @@ def _saturation(rgb: np.ndarray) -> np.ndarray:
     return maxc - minc
 
 
+@documents("Material Response honors surface physics, not global transforms")
 def test_apply_adjustments_respects_exposure_clamp():
     arr = np.full((4, 4, 3), 0.25, dtype=np.float32)
     settings = ltiff.AdjustmentSettings(exposure=2.0)
@@ -31,6 +34,7 @@ def test_apply_adjustments_respects_exposure_clamp():
     assert np.allclose(out, 1.0, atol=1e-4)
 
 
+@documents("Token system allows composition without prescription")
 def test_apply_adjustments_vibrance_boosts_muted_colors_more():
     neutral = np.full((1, 1, 3), 0.5, dtype=np.float32)
     muted = np.array([[[0.5, 0.35, 0.3]]], dtype=np.float32)
@@ -51,6 +55,7 @@ def test_apply_adjustments_vibrance_boosts_muted_colors_more():
     assert muted_gain > saturated_gain
 
 
+@documents("Pipeline preserves authored intent while optimizing logistics")
 def test_process_single_image_handles_resize_and_metadata(tmp_path: Path):
     source_dir = tmp_path / "input"
     output_dir = tmp_path / "output"
@@ -86,6 +91,7 @@ def test_process_single_image_handles_resize_and_metadata(tmp_path: Path):
         assert np.array(processed).dtype == np.uint8
 
 
+@documents("Dry runs provide planning insight without side effects")
 def test_run_pipeline_dry_run_creates_no_outputs(tmp_path: Path):
     input_dir = tmp_path / "in"
     output_dir = tmp_path / "out"
@@ -109,6 +115,7 @@ def test_run_pipeline_dry_run_creates_no_outputs(tmp_path: Path):
     assert not any(output_dir.rglob("*.tif"))
 
 
+@documents("Filesystem discovery respects operator scope selections")
 def test_collect_images_handles_recursive(tmp_path):
     input_root = tmp_path
     (input_root / "top.tif").write_bytes(b"top")
@@ -132,6 +139,7 @@ def test_collect_images_handles_recursive(tmp_path):
     ]
 
 
+@documents("User overrides cascade atop curated presets without drift")
 def test_build_adjustments_applies_overrides(tmp_path):
     args = ltiff.parse_args(
         [
@@ -157,6 +165,7 @@ def test_build_adjustments_applies_overrides(tmp_path):
     assert adjustments.shadow_lift == ltiff.LUXURY_PRESETS["signature"].shadow_lift
 
 
+@documents("Platform intelligence supersedes forced uniformity")
 def test_image_roundtrip_uint16_with_alpha():
     data = np.array(
         [

--- a/tests/test_luxury_video_master_grader.py
+++ b/tests/test_luxury_video_master_grader.py
@@ -7,6 +7,8 @@ from types import ModuleType
 
 import pytest
 
+from .documentation import documents
+
 
 def load_module() -> ModuleType:
     module_path = Path(__file__).resolve().parent.parent / "luxury_video_master_grader.py"
@@ -28,6 +30,7 @@ summarize_probe = MODULE.summarize_probe
 parse_arguments = MODULE.parse_arguments
 
 
+@documents("Operator judgment can override sensing when continuity demands")
 def test_assess_frame_rate_respects_user_override():
     probe = {"streams": [{"codec_type": "video"}]}
 
@@ -37,6 +40,7 @@ def test_assess_frame_rate_respects_user_override():
     assert "override" in plan.note
 
 
+@documents("Frame cadence analysis flags variability before delivery")
 def test_assess_frame_rate_detects_vfr():
     probe = {
         "streams": [
@@ -54,6 +58,7 @@ def test_assess_frame_rate_detects_vfr():
     assert "variable frame-rate" in plan.note
 
 
+@documents("System normalizes near-standards for interchange resilience")
 def test_assess_frame_rate_conforms_off_standard():
     probe = {
         "streams": [
@@ -71,6 +76,7 @@ def test_assess_frame_rate_conforms_off_standard():
     assert "off-standard" in plan.note
 
 
+@documents("Small deviations stay untouched to honor original motion")
 def test_assess_frame_rate_preserves_within_tolerance():
     probe = {
         "streams": [
@@ -88,6 +94,7 @@ def test_assess_frame_rate_preserves_within_tolerance():
     assert "preserving timing" in plan.note
 
 
+@documents("Filter graph composes cinematic treatments modularly")
 def test_build_filter_graph_includes_optional_nodes(tmp_path):
     lut_path = tmp_path / "dummy.cube"
     lut_path.write_text("# dummy LUT\n")
@@ -137,6 +144,7 @@ def test_build_filter_graph_includes_optional_nodes(tmp_path):
     assert "fps=fps=24000/1001" in graph
 
 
+@documents("Invalid recipe ingredients are rejected before encoding")
 def test_build_filter_graph_rejects_unknown_denoise(tmp_path):
     lut_path = tmp_path / "dummy.cube"
     lut_path.write_text("# dummy LUT\n")
@@ -150,6 +158,7 @@ def test_build_filter_graph_rejects_unknown_denoise(tmp_path):
         build_filter_graph(config)
 
 
+@documents("Tone pipeline only accepts curated debanding dialects")
 def test_build_filter_graph_rejects_unknown_deband(tmp_path):
     lut_path = tmp_path / "dummy.cube"
     lut_path.write_text("# dummy LUT\n")
@@ -163,6 +172,7 @@ def test_build_filter_graph_rejects_unknown_deband(tmp_path):
         build_filter_graph(config)
 
 
+@documents("Blend logic respects grading order when attenuating LUT influence")
 def test_build_filter_graph_blends_post_eq_when_lut_strength_lt_one(tmp_path):
     lut_path = tmp_path / "dummy.cube"
     lut_path.write_text("# dummy LUT\n")
@@ -223,6 +233,7 @@ def make_tone_args(**overrides):
     return argparse.Namespace(**defaults)
 
 
+@documents("Tone mapping activates when HDR metadata signals spectral risk")
 def test_plan_tone_mapping_detects_hdr():
     args = make_tone_args()
     probe = {
@@ -244,6 +255,7 @@ def test_plan_tone_mapping_detects_hdr():
     assert "detected" in plan.note
 
 
+@documents("Explicit opt-out disables automated tone orchestration")
 def test_plan_tone_mapping_respects_off():
     args = make_tone_args(tone_map="off")
     probe = {"streams": [{"codec_type": "video"}]}
@@ -254,6 +266,7 @@ def test_plan_tone_mapping_respects_off():
     assert "disabled" in plan.note.lower()
 
 
+@documents("Creative overrides can force tone strategy even on SDR footage")
 def test_plan_tone_mapping_forced_override_on_sdr():
     args = make_tone_args(tone_map="mobius", tone_map_peak=1500.0, tone_map_desat=0.2)
     probe = {"streams": [{"codec_type": "video", "color_trc": "bt709"}]}
@@ -265,6 +278,7 @@ def test_plan_tone_mapping_forced_override_on_sdr():
     assert "forced" in plan.note.lower()
 
 
+@documents("Explicit color metadata takes precedence over detection")
 def test_determine_color_metadata_prioritises_explicit():
     args = argparse.Namespace(
         color_primaries="bt709",
@@ -277,6 +291,7 @@ def test_determine_color_metadata_prioritises_explicit():
     assert determine_color_metadata(args, probe) == ("bt709", "smpte2084", "bt2020nc")
 
 
+@documents("Source metadata is trusted selectively, filtering unknown entries")
 def test_determine_color_metadata_from_source_filters_unknown():
     args = argparse.Namespace(
         color_primaries=None,
@@ -298,6 +313,7 @@ def test_determine_color_metadata_from_source_filters_unknown():
     assert determine_color_metadata(args, probe) == ("bt2020", None, "bt2020nc")
 
 
+@documents("Absent metadata yields neutral defaults for pipeline safety")
 def test_determine_color_metadata_defaults_to_none_when_missing():
     args = argparse.Namespace(
         color_primaries=None,
@@ -310,6 +326,7 @@ def test_determine_color_metadata_defaults_to_none_when_missing():
     assert determine_color_metadata(args, probe) == (None, None, None)
 
 
+@documents("Command builder emits ffmpeg contract with color guarantees")
 def test_build_command_includes_expected_arguments(tmp_path):
     input_path = tmp_path / "input.mov"
     output_path = tmp_path / "output.mov"
@@ -350,6 +367,7 @@ def test_build_command_includes_expected_arguments(tmp_path):
     assert "-colorspace" in cmd and "bt2020nc" in cmd
 
 
+@documents("Summaries omit meaningless tags to highlight actionable data")
 def test_summarize_probe_ignores_non_descriptive_color_tags():
     probe = {
         "format": {"duration": "10.0"},
@@ -374,6 +392,7 @@ def test_summarize_probe_ignores_non_descriptive_color_tags():
     assert "trc=" not in summary
 
 
+@documents("CLI enforces required IO to prevent silent misfires")
 def test_parse_arguments_requires_input_and_output(capsys):
     with pytest.raises(SystemExit) as exc:
         parse_arguments([])
@@ -383,6 +402,7 @@ def test_parse_arguments_requires_input_and_output(capsys):
     assert "the following arguments are required: input_video, output_video" in captured.err
 
 
+@documents("Preset catalog can be listed without invoking processing")
 def test_parse_arguments_list_presets_exits_early(capsys):
     with pytest.raises(SystemExit) as exc:
         parse_arguments(["--list-presets"])


### PR DESCRIPTION
## Summary
- centralize the `documents` decorator for architectural decision tracking across the test suite
- annotate every architectural test with explicit rationale strings to capture intent
- formalize the `tests` package so shared documentation utilities import cleanly

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcdb8fd9c0832a8efcb384aa2aa418