### PR TITLE
Document gradient token architecture for Lantern logo kit

### DIFF
--- a/09_Client_Deliverables/Lantern_Logo_Implementation_Kit/README.md
+++ b/09_Client_Deliverables/Lantern_Logo_Implementation_Kit/README.md
@@ -9,3 +9,10 @@ This package mirrors the Lantern component specification so designers and engine
 - `lantern_logo.svg` — Accessibility-ready master mark that consumes the token variables, exposes the gradient definition, and preserves the vessel and flame geometry described in the component spec.
 
 For governance details, geometry rules, and motion guidance, reference `../../08_Documentation/lantern_logo_component_spec.md`.
+
+## Gradient architecture
+
+- The reference `lantern_logo.svg` composes its flame gradient using the primitive color tokens `color.brand.azure` and `color.brand.cyan`, ensuring the SVG automatically reflects any upstream palette changes.
+- When defining `gradient.brand.primary` in `lantern_tokens.json`, compose the gradient stops from the existing primitive tokens (or add new primitives first) so Style Dictionary outputs inherit the canonical palette described in the [component specification](../../08_Documentation/lantern_logo_component_spec.md#3-token-system).
+
+> **Caution:** Always update or extend the primitive color tokens before adjusting gradient definitions, and avoid hard-coding new hexadecimal values directly into gradient tokens or SVG assets.


### PR DESCRIPTION
## Summary
- add a gradient architecture section to the Lantern logo implementation README so contributors understand how the SVG and tokens compose brand colors
- reinforce that gradient tokens should be built from primitive colors and link back to the component specification for context
- warn contributors to update primitives first and avoid hard-coding new hex values in gradients

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68dce0e9a28c832a810901f461ee6902