### PR TITLE
Document gradient primitive dependency in component spec

### DIFF
--- a/08_Documentation/lantern_logo_component_spec.md
+++ b/08_Documentation/lantern_logo_component_spec.md
@@ -29,7 +29,7 @@ Primitive brand tokens are defined in [`lantern_tokens.json`](../09_Client_Deliv
 | `color.brand.azure` | `#56CCF2` | Gradient highlight stop. |
 | `color.brand.ice` | `#E5F6FF` | Glyph background and elevated surfaces. |
 | `color.brand.white` | `#FFFFFF` | Neutral content surface. |
-| `gradient.brand.primary` | Linear, 160°, stops at `#3AE0FF` → `#0784D9` | Applied on interaction hover/focus states and motion trails. |
+| `gradient.brand.primary` | Linear, 160°, stops reference `color.brand.azure` → `color.brand.cyan` | Applied on interaction hover/focus states and motion trails; update primitive stops first to cascade changes. |
 
 Semantic variables (e.g., `--lantern-stroke`, `--lantern-hover-glow`) must be derived from these primitives to maintain cross-platform parity.
 

--- a/09_Client_Deliverables/Lantern_Logo_Implementation_Kit/README.md
+++ b/09_Client_Deliverables/Lantern_Logo_Implementation_Kit/README.md
@@ -9,3 +9,10 @@ This package mirrors the Lantern component specification so designers and engine
 - `lantern_logo.svg` — Accessibility-ready master mark that consumes the token variables, exposes the gradient definition, and preserves the vessel and flame geometry described in the component spec.
 
 For governance details, geometry rules, and motion guidance, reference `../../08_Documentation/lantern_logo_component_spec.md`.
+
+## Gradient architecture
+
+- The reference `lantern_logo.svg` composes its flame gradient using the primitive color tokens `color.brand.azure` and `color.brand.cyan`, ensuring the SVG automatically reflects any upstream palette changes.
+- When defining `gradient.brand.primary` in `lantern_tokens.json`, compose the gradient stops from the existing primitive tokens (or add new primitives first) so Style Dictionary outputs inherit the canonical palette described in the [component specification](../../08_Documentation/lantern_logo_component_spec.md#3-token-system).
+
+> **Caution:** Always update or extend the primitive color tokens before adjusting gradient definitions, and avoid hard-coding new hexadecimal values directly into gradient tokens or SVG assets.


### PR DESCRIPTION
## Summary
- align the gradient token row in the Lantern logo component spec with guidance to build stops from brand primitives
- remind maintainers within the spec to update primitive colors first so gradient changes cascade correctly

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dce0e9a28c832a810901f461ee6902