### PR TITLE
Add temporal guard for Lantern logo gradient test

### DIFF
--- a/tests/documentation.py
+++ b/tests/documentation.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Callable, TypeVar
+from datetime import date
+from functools import wraps
+from typing import Callable, TypeVar, cast
 
 F = TypeVar("F", bound=Callable[..., object])
 
@@ -17,5 +19,37 @@ def documents(note: str) -> Callable[[F], F]:
     return decorator
 
 
-__all__ = ["documents"]
+def valid_until(iso_date: str, *, reason: str) -> Callable[[F], F]:
+    """Fail the decorated test once the provided date has passed.
+
+    This helper acts as a temporal contract around architectural decisions: once
+    the stated expiry date is exceeded the test will raise an assertion failure,
+    signalling that the guarded assumption needs to be reviewed.
+    """
+
+    deadline = date.fromisoformat(iso_date)
+
+    def decorator(func: F) -> F:
+        note = f"Valid until {deadline.isoformat()} – {reason}"
+
+        @wraps(func)
+        def wrapper(*args: object, **kwargs: object):
+            today = date.today()
+            if today > deadline:
+                raise AssertionError(
+                    "Temporal contract expired: "
+                    f"{func.__name__!r} requires review after {deadline.isoformat()} "
+                    f"because {reason}."
+                )
+            return func(*args, **kwargs)
+
+        wrapper.__doc__ = (
+            note if func.__doc__ is None else f"{note}\n{func.__doc__}"
+        )
+        return cast(F, wrapper)
+
+    return decorator
+
+
+__all__ = ["documents", "valid_until"]
 

--- a/tests/test_lantern_logo_css.py
+++ b/tests/test_lantern_logo_css.py
@@ -8,7 +8,7 @@ import re
 ROOT = Path(__file__).resolve().parent.parent
 CSS_PATH = ROOT / "09_Client_Deliverables" / "Lantern_Logo_Implementation_Kit" / "lantern_logo.css"
 
-from .documentation import documents
+from .documentation import documents, valid_until
 
 
 def _extract_hover_block(css: str) -> str:
@@ -32,6 +32,7 @@ def _extract_stroke_value(block: str) -> str:
 
 
 @documents("Logo uses SVG gradient on hover, not brand gradient")
+@valid_until("2026-01-01", reason="Review after brand refresh cycle")
 def test_hover_gradient_source() -> None:
     css = CSS_PATH.read_text(encoding="utf-8")
     hover_block = _extract_hover_block(css)


### PR DESCRIPTION
## Summary
- add a `valid_until` decorator so architectural tests can enforce review deadlines
- annotate the Lantern logo hover gradient test with a review date tied to the brand refresh cycle

## Testing
- pytest tests/test_lantern_logo_css.py

------
https://chatgpt.com/codex/tasks/task_e_68dce96b9258832aa8a17b0fba643ffb