### PR TITLE
Add gradient composition helper with primitive guardrails

### DIFF
--- a/09_Client_Deliverables/Lantern_Logo_Implementation_Kit/README.md
+++ b/09_Client_Deliverables/Lantern_Logo_Implementation_Kit/README.md
@@ -5,6 +5,7 @@ This package mirrors the Lantern component specification so designers and engine
 ## Contents
 
 - `lantern_tokens.json` — Primitive color and gradient tokens structured for Style Dictionary compilation into CSS, iOS, Android, and Figma targets.
+- `gradient_composer.js` — Utility that composes gradients from primitive tokens and warns when custom stops bypass the palette guardrails.
 - `lantern_logo.css` — Web starter styles illustrating how to compose semantic CSS variables, responsive padding, and hover affordances from the primitive token set.
 - `lantern_logo.svg` — Accessibility-ready master mark that consumes the token variables, exposes the gradient definition, and preserves the vessel and flame geometry described in the component spec.
 
@@ -14,5 +15,6 @@ For governance details, geometry rules, and motion guidance, reference `../../08
 
 - The reference `lantern_logo.svg` composes its flame gradient using the primitive color tokens `color.brand.azure` and `color.brand.cyan`, ensuring the SVG automatically reflects any upstream palette changes.
 - When defining `gradient.brand.primary` in `lantern_tokens.json`, compose the gradient stops from the existing primitive tokens (or add new primitives first) so Style Dictionary outputs inherit the canonical palette described in the [component specification](../../08_Documentation/lantern_logo_component_spec.md#3-token-system).
+- The accompanying `gradient_composer.js` helper surfaces console warnings whenever gradient stops fall back to ad-hoc hex values. Call `composeGradient([{ position: 0, color: '{color.brand.azure}' }, …])` to receive a CSS-ready gradient string while automatically mapping references to their corresponding custom properties.
 
 > **Caution:** Always update or extend the primitive color tokens before adjusting gradient definitions, and avoid hard-coding new hexadecimal values directly into gradient tokens or SVG assets.

--- a/09_Client_Deliverables/Lantern_Logo_Implementation_Kit/gradient_composer.js
+++ b/09_Client_Deliverables/Lantern_Logo_Implementation_Kit/gradient_composer.js
@@ -1,0 +1,116 @@
+'use strict';
+
+const tokens = require('./lantern_tokens.json');
+
+const BRAND_COLOR_KEY = ['tokens', 'color', 'brand'];
+
+const brandPalette = BRAND_COLOR_KEY.reduce(
+  (acc, key) => (acc && acc[key] ? acc[key] : {}),
+  tokens
+);
+
+const brandColors = Object.entries(brandPalette);
+
+const PRIMITIVE_REF_SET = new Set(
+  brandColors.map(([name]) => `color.brand.${name}`)
+);
+
+const PRIMITIVE_HEX_SET = new Set(
+  brandColors
+    .map(([, descriptor]) => descriptor.value)
+    .filter((value) => typeof value === 'string')
+    .map((value) => value.trim().toLowerCase())
+);
+
+function normalizeTokenReference(color) {
+  if (typeof color !== 'string') {
+    return '';
+  }
+  const trimmed = color.trim();
+  if (trimmed.startsWith('{') && trimmed.endsWith('}')) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function isPrimitive(color) {
+  const ref = normalizeTokenReference(color);
+
+  if (PRIMITIVE_REF_SET.has(ref)) {
+    return true;
+  }
+
+  if (/^#[0-9a-f]{6}$/i.test(ref)) {
+    return PRIMITIVE_HEX_SET.has(ref.toLowerCase());
+  }
+
+  return false;
+}
+
+function toCssCustomProperty(ref) {
+  if (ref.startsWith('color.brand.')) {
+    const [, , ...parts] = ref.split('.');
+    return `var(--brand-${parts.join('-')})`;
+  }
+  return ref;
+}
+
+function resolveColor(color) {
+  const ref = normalizeTokenReference(color);
+  if (PRIMITIVE_REF_SET.has(ref)) {
+    return toCssCustomProperty(ref);
+  }
+  return color;
+}
+
+function formatStopPosition(position) {
+  if (typeof position !== 'number' || Number.isNaN(position)) {
+    return position;
+  }
+  const percentage = position * 100;
+  return `${Number.parseFloat(percentage.toFixed(2))}%`;
+}
+
+function createGradient(stops, options = {}) {
+  const { rotation = 160 } = options;
+  const orderedStops = [...stops].sort((a, b) => {
+    if (typeof a.position !== 'number' || typeof b.position !== 'number') {
+      return 0;
+    }
+    return a.position - b.position;
+  });
+
+  const stopList = orderedStops
+    .map((stop) => {
+      const color = resolveColor(stop.color);
+      const position = formatStopPosition(stop.position);
+      return position ? `${color} ${position}` : color;
+    })
+    .join(', ');
+
+  return `linear-gradient(${rotation}deg, ${stopList})`;
+}
+
+function composeGradient(stops, options = {}) {
+  const { allowOrphans = false } = options;
+
+  if (!allowOrphans) {
+    stops.forEach((stop) => {
+      if (!isPrimitive(stop.color)) {
+        console.warn(
+          `Orphan color ${stop.color} detected. ` +
+            'Consider adding to primitives or set allowOrphans: true'
+        );
+      }
+    });
+  }
+
+  return createGradient(stops, options);
+}
+
+module.exports = {
+  composeGradient,
+  createGradient,
+  isPrimitive,
+  resolveColor,
+};

--- a/09_Client_Deliverables/Lantern_Logo_Implementation_Kit/lantern_logo.css
+++ b/09_Client_Deliverables/Lantern_Logo_Implementation_Kit/lantern_logo.css
@@ -4,7 +4,11 @@
   --brand-azure: #56CCF2;
   --brand-ice: #E5F6FF;
   --brand-white: #FFFFFF;
-  --brand-gradient: linear-gradient(160deg, #3AE0FF 0%, #0784D9 100%);
+  --brand-gradient: linear-gradient(
+    160deg,
+    var(--brand-azure) 0%,
+    var(--brand-cyan) 100%
+  );
   --lantern-stroke: var(--brand-cyan);
   --lantern-hover-glow: 0 0 24px rgba(42, 199, 255, 0.45);
 }

--- a/09_Client_Deliverables/Lantern_Logo_Implementation_Kit/lantern_tokens.json
+++ b/09_Client_Deliverables/Lantern_Logo_Implementation_Kit/lantern_tokens.json
@@ -17,8 +17,8 @@
             "type": "linear",
             "rotation": 160,
             "stops": [
-              { "position": 0, "color": "#3AE0FF" },
-              { "position": 1, "color": "#0784D9" }
+              { "position": 0, "color": "{color.brand.azure}" },
+              { "position": 1, "color": "{color.brand.cyan}" }
             ]
           }
         }


### PR DESCRIPTION
## Summary
- add a gradient composition helper that maps token references and warns when stops are not tied to primitives
- align the Lantern logo CSS and token definitions so gradients reference primitive colors instead of raw hex values
- document the new helper inside the implementation kit README for engineers consuming the assets

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcea9d4afc832a9260711baa3d8148