### PR TITLE
Add reveal interaction token and align CSS transition

### DIFF
--- a/09_Client_Deliverables/Lantern_Logo_Implementation_Kit/lantern_logo.css
+++ b/09_Client_Deliverables/Lantern_Logo_Implementation_Kit/lantern_logo.css
@@ -11,6 +11,8 @@
   );
   --lantern-stroke: var(--brand-cyan);
   --lantern-hover-glow: 0 0 24px rgba(42, 199, 255, 0.45);
+  --lantern-reveal-duration: 150ms;
+  --lantern-reveal-easing: ease;
 }
 
 body {
@@ -33,7 +35,9 @@ body {
   width: 100%;
   height: auto;
   stroke: var(--lantern-stroke, currentColor);
-  transition: stroke 150ms ease, filter 200ms ease;
+  transition:
+    stroke var(--lantern-reveal-duration, 150ms) var(--lantern-reveal-easing, ease),
+    filter var(--lantern-reveal-duration, 150ms) var(--lantern-reveal-easing, ease);
 }
 
 .lantern-logo[data-variant="glyph"] {

--- a/09_Client_Deliverables/Lantern_Logo_Implementation_Kit/lantern_tokens.json
+++ b/09_Client_Deliverables/Lantern_Logo_Implementation_Kit/lantern_tokens.json
@@ -23,6 +23,14 @@
           }
         }
       }
+    },
+    "interaction": {
+      "reveal": {
+        "type": { "value": "transition" },
+        "trigger": { "value": "hover" },
+        "duration": { "value": "150ms" },
+        "easing": { "value": "ease" }
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- add an interaction.reveal token that captures the hover transition specification
- expose the reveal timing metadata as CSS custom properties
- update the lantern logo SVG transition to consume the shared timing variables

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dcec0e43fc832ab966268ebb742cc4