### PR TITLE
Add Material Response principle helpers

### DIFF
--- a/material_response.py
+++ b/material_response.py
@@ -1,0 +1,106 @@
+"""Material Response principle support utilities.
+
+The marketing material for the 800 Picacho Lane collection repeatedly alludes
+to a proprietary "Material Response" technology.  The production codebase does
+not actually perform physically based rendering, but we can still document what
+the principle *means* so tests and documentation have a concrete artefact to
+reference.  This module provides such an artefact.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List
+
+
+@dataclass(frozen=True)
+class MaterialResponseExample:
+    """Structured example describing how the principle manifests."""
+
+    material: str
+    lighting: str
+    challenge: str
+    response: str
+    outcome: str
+
+    def as_dict(self) -> Dict[str, str]:
+        """Return the example in a serialisable dictionary form."""
+
+        return {
+            "material": self.material,
+            "lighting": self.lighting,
+            "challenge": self.challenge,
+            "response": self.response,
+            "outcome": self.outcome,
+        }
+
+
+class MaterialResponsePrinciple:
+    """Captures the intent behind the Material Response marketing claims.
+
+    The principle is intentionally high-level: it frames how surface-specific
+    adjustments should be reasoned about even when a pipeline primarily applies
+    tone and colour transforms.  Tests that refer to this principle can inspect
+    the structured data returned here without coupling to any particular image
+    processing implementation.
+    """
+
+    name: str = "Material Response"
+    focus: str = (
+        "Honor the unique light interaction of each surface instead of applying "
+        "purely global transforms."
+    )
+
+    tenets: List[str] = [
+        "Respect energy conservation in highlights so reflective materials retain believable sheen.",
+        "Preserve midtone texture to keep organic materials tactile and dimensional.",
+        "Blend transitions between adjacent materials so adjustments feel authored rather than procedural.",
+    ]
+
+    def describe(self) -> str:
+        """Return a human readable description of the principle."""
+
+        return f"{self.name}: {self.focus}"
+
+    def guidelines(self) -> List[str]:
+        """Return the set of guiding tenets."""
+
+        return list(self.tenets)
+
+    def generate_examples(self) -> List[Dict[str, str]]:
+        """Produce canonical examples demonstrating the principle in action.
+
+        The examples intentionally cover a variety of materials.  Returning
+        dictionaries keeps the data ergonomic for documentation tooling and
+        avoids a dependency on this module's dataclass by callers.
+        """
+
+        examples: Iterable[MaterialResponseExample] = [
+            MaterialResponseExample(
+                material="polished marble foyer",
+                lighting="late-afternoon sun grazing through clerestory windows",
+                challenge="Specular highlights risk clipping and flattening the stone veining.",
+                response="Apply highlight recovery before clarity so micro-contrast is boosted only after energy is preserved.",
+                outcome="Marble retains luminous sheen with detailed veining rather than a white patch.",
+            ),
+            MaterialResponseExample(
+                material="brushed brass fixtures",
+                lighting="mixed tungsten sconces and cool daylight",
+                challenge="Mixed colour temperatures create muddy warm-cool interference on the anisotropic metal.",
+                response="Balance tint locally while moderating saturation to keep the brushed texture defined.",
+                outcome="Brass reads as intentionally warm while grooves stay articulated.",
+            ),
+            MaterialResponseExample(
+                material="velvet chaise",
+                lighting="soft bounced fill with narrow specular kicker",
+                challenge="Global contrast lift would crush the velvet's directionality and make it plastic.",
+                response="Target midtone contrast and vibrance to maintain pile shading while enriching dye density.",
+                outcome="Velvet keeps tactile depth and directional sheen without waxy highlights.",
+            ),
+        ]
+
+        return [example.as_dict() for example in examples]
+
+
+__all__ = ["MaterialResponsePrinciple", "MaterialResponseExample"]
+

--- a/tests/documentation.py
+++ b/tests/documentation.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import date
 from functools import wraps
+from collections.abc import Iterable
 from typing import Callable, TypeVar, cast
 
 F = TypeVar("F", bound=Callable[..., object])
@@ -15,6 +16,42 @@ def documents(note: str) -> Callable[[F], F]:
     def decorator(func: F) -> F:
         func.__doc__ = note if func.__doc__ is None else f"{note}\n{func.__doc__}"
         return func
+
+    return decorator
+
+
+def demonstrates(concepts: Iterable[object] | object) -> Callable[[F], F]:
+    """Annotate a test subject with the concept(s) it proves out.
+
+    The decorator mirrors :func:`documents` but is semantically distinct: it
+    links a test to one or more architectural principles that the test
+    exercises.  The relationship is recorded on the decorated object via a
+    ``__demonstrates__`` attribute so that meta-tests or documentation tooling
+    can surface the mapping between principles and coverage.
+
+    The decorator accepts either a single concept (for convenience) or an
+    iterable of concepts.  Concepts may be strings, classes, or any other
+    descriptive object; they are stored verbatim and an informative docstring
+    note is prefixed so the intent shows up in pytest's verbose output.
+    """
+
+    if isinstance(concepts, (str, bytes)) or not isinstance(concepts, Iterable):
+        concept_list = [concepts]
+    else:
+        concept_list = list(concepts)
+
+    def decorator(obj: F) -> F:
+        note_parts = []
+        for concept in concept_list:
+            if hasattr(concept, "__name__"):
+                note_parts.append(concept.__name__)  # type: ignore[arg-type]
+            else:
+                note_parts.append(str(concept))
+
+        note = "Demonstrates: " + ", ".join(note_parts)
+        obj.__doc__ = note if obj.__doc__ is None else f"{note}\n{obj.__doc__}"
+        setattr(obj, "__demonstrates__", tuple(concept_list))
+        return obj
 
     return decorator
 
@@ -51,5 +88,5 @@ def valid_until(iso_date: str, *, reason: str) -> Callable[[F], F]:
     return decorator
 
 
-__all__ = ["documents", "valid_until"]
+__all__ = ["documents", "demonstrates", "valid_until"]
 


### PR DESCRIPTION
## Summary
- add a `demonstrates` decorator so tests can link to architectural principles
- provide a `MaterialResponsePrinciple` reference module with structured examples for documentation tooling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dced236530832abd4123380ddd0d69