### PR TITLE
Add decision decay dashboard CLI and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A cutting-edge collection of **16 professional color grading LUTs** featuring in
     - [HDR Production Pipeline Highlights](#hdr-production-pipeline-highlights)
     - [HDR Production Pipeline Requirements](#hdr-production-pipeline-requirements)
     - [HDR Production Pipeline Example](#hdr-production-pipeline-example)
+- [Decision Decay Dashboard](#decision-decay-dashboard)
 - [License](#license)
 
 ## Collection Contents
@@ -129,6 +130,21 @@ Layer the script after `luxury_video_master_grader.py` to apply bespoke LUTs bef
 HDR-specific finishing tools run. The pipeline preserves Dolby Vision and static HDR10
 metadata where available, while the deband and halation stages default to the Codex branch
 recipes highlighted in the documentation examples.
+
+## Decision Decay Dashboard
+
+`decision_decay_dashboard.py` surfaces temporal contracts, codebase philosophy violations, and brand color token drift in a single terminal dashboard.
+It cross-references `tests/` for `@valid_until` decorators, audits Python sources with `CodebasePhilosophyAuditor`, and highlights unused color tokens
+from the Lantern logo deliverables so teams know what requires attention next.
+
+### Running the dashboard
+```bash
+python decision_decay_dashboard.py
+```
+
+Use `--root` to audit a different project tree, `--tests` or `--tokens` to point at alternate assets, and `--json <path>` to export the findings for downstream
+automation. Near-term `valid_until` expirations are flagged in yellow when `rich` is installed (or with a `!` prefix in plain text). Philosophy violations are
+aggregated by principle with example file locations, while the color section lists which brand hex values are still unused in CSS/JS deliverables.
 
 ## License
 Professional use permitted with attribution.

--- a/decision_decay_dashboard.py
+++ b/decision_decay_dashboard.py
@@ -1,0 +1,433 @@
+"""CLI utility that surfaces temporal contracts, philosophy violations, and color token drift."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence
+
+from codebase_philosophy_auditor import CodebasePhilosophyAuditor, Violation
+
+
+@dataclass
+class ValidUntilRecord:
+    """Representation of a ``valid_until`` decorator instance."""
+
+    target: str
+    deadline: date
+    reason: str
+    path: Path
+    line: int
+
+    @property
+    def days_remaining(self) -> int:
+        return (self.deadline - date.today()).days
+
+
+@dataclass
+class PrincipleSummary:
+    """Aggregate information about a philosophy principle's violations."""
+
+    principle: str
+    count: int
+    examples: List[str]
+
+
+@dataclass
+class ColorTokenUsage:
+    token: str
+    hex_value: str
+    used_in: List[str]
+
+
+@dataclass
+class ColorTokenReport:
+    tokens: List[ColorTokenUsage]
+    orphans: List[ColorTokenUsage]
+
+
+def collect_valid_until_records(tests_root: Path) -> List[ValidUntilRecord]:
+    """Discover and sort ``valid_until`` decorators within *tests_root*."""
+
+    records: List[ValidUntilRecord] = []
+    for path in sorted(tests_root.rglob("*.py")):
+        try:
+            tree = ast.parse(path.read_text(), filename=str(path))
+        except SyntaxError:
+            continue
+
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                continue
+            for decorator in node.decorator_list:
+                record = _valid_until_from_decorator(decorator, path)
+                if record is not None:
+                    records.append(
+                        ValidUntilRecord(
+                            target=node.name,
+                            deadline=record[0],
+                            reason=record[1],
+                            path=path,
+                            line=decorator.lineno,
+                        )
+                    )
+
+    return sorted(records, key=lambda item: item.days_remaining)
+
+
+def _valid_until_from_decorator(
+    decorator: ast.AST, path: Path
+) -> Optional[tuple[date, str]]:
+    if not isinstance(decorator, ast.Call):
+        return None
+
+    func = decorator.func
+    if isinstance(func, ast.Name):
+        func_name = func.id
+    elif isinstance(func, ast.Attribute):
+        func_name = func.attr
+    else:
+        return None
+
+    if func_name != "valid_until":
+        return None
+
+    if not decorator.args:
+        return None
+
+    try:
+        deadline_value = ast.literal_eval(decorator.args[0])
+    except Exception as exc:  # pragma: no cover - defensive
+        raise ValueError(f"Unable to evaluate valid_until deadline in {path}") from exc
+
+    if not isinstance(deadline_value, str):
+        raise ValueError(
+            f"valid_until decorator in {path} must use a string ISO date literal"
+        )
+
+    reason_value: Optional[str] = None
+    if decorator.keywords:
+        for keyword in decorator.keywords:
+            if keyword.arg == "reason":
+                reason_value = ast.literal_eval(keyword.value)
+                break
+
+    if reason_value is None:
+        raise ValueError(
+            f"valid_until decorator in {path} is missing required 'reason' keyword"
+        )
+
+    if not isinstance(reason_value, str):
+        raise ValueError(
+            f"valid_until decorator in {path} must use a string reason literal"
+        )
+
+    deadline = date.fromisoformat(deadline_value)
+    return deadline, reason_value
+
+
+def collect_philosophy_violations(
+    paths: Iterable[Path], *, auditor: Optional[CodebasePhilosophyAuditor] = None
+) -> Dict[str, PrincipleSummary]:
+    """Aggregate :class:`Violation` instances returned by *auditor*."""
+
+    auditor = auditor or CodebasePhilosophyAuditor()
+    summaries: Dict[str, PrincipleSummary] = {}
+
+    for module_path in _iter_python_files(paths):
+        violations = auditor.audit_module(module_path)
+        for violation in violations:
+            summary = summaries.get(violation.principle)
+            location = _format_violation_location(module_path, violation)
+            if summary is None:
+                summaries[violation.principle] = PrincipleSummary(
+                    principle=violation.principle,
+                    count=1,
+                    examples=[location],
+                )
+            else:
+                summary.count += 1
+                if len(summary.examples) < 3:
+                    summary.examples.append(location)
+
+    return summaries
+
+
+def _iter_python_files(paths: Iterable[Path]) -> Iterable[Path]:
+    for path in paths:
+        if path.is_dir():
+            yield from (p for p in path.rglob("*.py") if p.is_file())
+        elif path.suffix == ".py":
+            yield path
+
+
+def _format_violation_location(module_path: Path, violation: Violation) -> str:
+    location = f"{module_path}" if violation.line is None else f"{module_path}:{violation.line}"
+    return f"{location} – {violation.message}"
+
+
+def collect_color_token_report(tokens_path: Path) -> ColorTokenReport:
+    """Return usage information for brand color tokens defined in *tokens_path*."""
+
+    tokens_data = json.loads(tokens_path.read_text())
+    brand_tokens = (
+        tokens_data.get("tokens", {})
+        .get("color", {})
+        .get("brand", {})
+    )
+
+    directory = tokens_path.parent
+    deliverables = [
+        path
+        for path in directory.iterdir()
+        if path.suffix.lower() in {".css", ".js", ".mjs", ".cjs"}
+    ]
+
+    usages: List[ColorTokenUsage] = []
+    orphans: List[ColorTokenUsage] = []
+
+    for token_name, descriptor in sorted(brand_tokens.items()):
+        value = descriptor.get("value")
+        if not isinstance(value, str):
+            continue
+        normalized_hex = value.strip().lower()
+        token_ref = f"color.brand.{token_name}"
+        css_var = f"--brand-{token_name.replace('_', '-')}"
+
+        used_in: List[str] = []
+        for deliverable in deliverables:
+            text = deliverable.read_text().lower()
+            if (
+                normalized_hex in text
+                or token_ref in text
+                or css_var in text
+            ):
+                used_in.append(deliverable.name)
+
+        usage = ColorTokenUsage(
+            token=token_name,
+            hex_value=normalized_hex,
+            used_in=used_in,
+        )
+        usages.append(usage)
+        if not used_in:
+            orphans.append(usage)
+
+    return ColorTokenReport(tokens=usages, orphans=orphans)
+
+
+def render_dashboard(
+    valid_until_records: Sequence[ValidUntilRecord],
+    principle_summaries: Dict[str, PrincipleSummary],
+    color_report: ColorTokenReport,
+) -> None:
+    """Render a textual dashboard summarising the collected insights."""
+
+    try:
+        from rich.console import Console
+        from rich.table import Table
+    except Exception:  # pragma: no cover - fallback when Rich unavailable
+        _render_plain_dashboard(valid_until_records, principle_summaries, color_report)
+        return
+
+    console = Console()
+
+    console.rule("Temporal Contracts")
+    table = Table(show_header=True, header_style="bold magenta")
+    table.add_column("Target")
+    table.add_column("Deadline")
+    table.add_column("Days Remaining", justify="right")
+    table.add_column("Reason")
+    table.add_column("Location")
+
+    for record in valid_until_records:
+        days_remaining = record.days_remaining
+        style = "yellow" if days_remaining <= 30 else None
+        table.add_row(
+            record.target,
+            record.deadline.isoformat(),
+            str(days_remaining),
+            record.reason,
+            f"{record.path.name}:{record.line}",
+            style=style,
+        )
+
+    if not valid_until_records:
+        table.add_row("(none)", "-", "-", "-", "-", style="dim")
+
+    console.print(table)
+
+    console.rule("Philosophy Violations")
+    pv_table = Table(show_header=True, header_style="bold magenta")
+    pv_table.add_column("Principle")
+    pv_table.add_column("Count", justify="right")
+    pv_table.add_column("Examples")
+
+    for summary in sorted(
+        principle_summaries.values(), key=lambda item: item.count, reverse=True
+    ):
+        pv_table.add_row(
+            summary.principle,
+            str(summary.count),
+            "\n".join(summary.examples),
+        )
+
+    if not principle_summaries:
+        pv_table.add_row("(none)", "0", "-", style="dim")
+
+    console.print(pv_table)
+
+    console.rule("Orphan Brand Colors")
+    orphan_table = Table(show_header=True, header_style="bold magenta")
+    orphan_table.add_column("Token")
+    orphan_table.add_column("Hex")
+    orphan_table.add_column("Used In")
+
+    for usage in color_report.tokens:
+        style = "red" if usage in color_report.orphans else None
+        orphan_table.add_row(
+            usage.token,
+            usage.hex_value,
+            ", ".join(usage.used_in) if usage.used_in else "(unused)",
+            style=style,
+        )
+
+    if not color_report.tokens:
+        orphan_table.add_row("(none)", "-", "-", style="dim")
+
+    console.print(orphan_table)
+
+
+def _render_plain_dashboard(
+    valid_until_records: Sequence[ValidUntilRecord],
+    principle_summaries: Dict[str, PrincipleSummary],
+    color_report: ColorTokenReport,
+) -> None:
+    print("=== Temporal Contracts ===")
+    if valid_until_records:
+        for record in valid_until_records:
+            marker = "!" if record.days_remaining <= 30 else "-"
+            print(
+                f"{marker} {record.target} – {record.deadline.isoformat()} "
+                f"({record.days_remaining} days) : {record.reason} "
+                f"[{record.path.name}:{record.line}]"
+            )
+    else:
+        print("No valid_until decorators discovered.")
+
+    print("\n=== Philosophy Violations ===")
+    if principle_summaries:
+        for summary in sorted(
+            principle_summaries.values(), key=lambda item: item.count, reverse=True
+        ):
+            print(f"- {summary.principle}: {summary.count}")
+            for example in summary.examples:
+                print(f"    • {example}")
+    else:
+        print("No violations detected.")
+
+    print("\n=== Orphan Brand Colors ===")
+    if color_report.tokens:
+        for usage in color_report.tokens:
+            status = "unused" if usage in color_report.orphans else "used"
+            print(
+                f"- {usage.token} ({usage.hex_value}): "
+                f"{', '.join(usage.used_in) if usage.used_in else status}"
+            )
+    else:
+        print("No brand colors found in token file.")
+
+
+def export_json(
+    destination: Path,
+    valid_until_records: Sequence[ValidUntilRecord],
+    principle_summaries: Dict[str, PrincipleSummary],
+    color_report: ColorTokenReport,
+) -> None:
+    payload = {
+        "valid_until": [
+            {
+                "target": record.target,
+                "deadline": record.deadline.isoformat(),
+                "reason": record.reason,
+                "path": str(record.path),
+                "line": record.line,
+                "days_remaining": record.days_remaining,
+            }
+            for record in valid_until_records
+        ],
+        "philosophy_violations": {
+            principle: {
+                "count": summary.count,
+                "examples": summary.examples,
+            }
+            for principle, summary in principle_summaries.items()
+        },
+        "color_tokens": [
+            {
+                "token": usage.token,
+                "hex": usage.hex_value,
+                "used_in": usage.used_in,
+                "unused": usage in color_report.orphans,
+            }
+            for usage in color_report.tokens
+        ],
+    }
+    destination.write_text(json.dumps(payload, indent=2))
+
+
+def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path.cwd(),
+        help="Project root used to locate tests and sources (defaults to CWD)",
+    )
+    parser.add_argument(
+        "--tests",
+        type=Path,
+        default=None,
+        help="Override the tests directory (defaults to <root>/tests)",
+    )
+    parser.add_argument(
+        "--tokens",
+        type=Path,
+        default=None,
+        help="Override the brand tokens file (defaults to repository deliverable)",
+    )
+    parser.add_argument(
+        "--json",
+        type=Path,
+        default=None,
+        help="Optional path to export the dashboard data as JSON",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> None:
+    args = parse_args(argv)
+    root = args.root.resolve()
+    tests_root = (args.tests or (root / "tests")).resolve()
+
+    if args.tokens is not None:
+        tokens_path = args.tokens.resolve()
+    else:
+        tokens_path = root / "09_Client_Deliverables" / "Lantern_Logo_Implementation_Kit" / "lantern_tokens.json"
+
+    valid_until_records = collect_valid_until_records(tests_root)
+    principle_summaries = collect_philosophy_violations([root])
+    color_report = collect_color_token_report(tokens_path)
+
+    if args.json:
+        export_json(args.json, valid_until_records, principle_summaries, color_report)
+
+    render_dashboard(valid_until_records, principle_summaries, color_report)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/tests/test_decision_decay_dashboard.py
+++ b/tests/test_decision_decay_dashboard.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+from datetime import date, timedelta
+from pathlib import Path
+
+
+from decision_decay_dashboard import (
+    collect_color_token_report,
+    collect_philosophy_violations,
+    collect_valid_until_records,
+)
+from codebase_philosophy_auditor import Violation
+
+
+def test_collect_valid_until_records_sorted(tmp_path):
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    module = tests_dir / "test_example.py"
+    deadline_a = (date.today() + timedelta(days=10)).isoformat()
+    deadline_b = (date.today() + timedelta(days=5)).isoformat()
+    module.write_text(
+        "from tests.documentation import valid_until\n\n"
+        f"@valid_until(\"{deadline_a}\", reason=\"Longer horizon\")\n"
+        "def test_future_a():\n    pass\n\n"
+        f"@valid_until(\"{deadline_b}\", reason=\"Soon\")\n"
+        "def test_future_b():\n    pass\n"
+    )
+
+    records = collect_valid_until_records(tests_dir)
+
+    assert [record.target for record in records] == ["test_future_b", "test_future_a"]
+    assert records[0].reason == "Soon"
+
+
+class DummyAuditor:
+    def __init__(self, violations: list[Violation]):
+        self._violations = violations
+        self.audited: list[Path] = []
+
+    def audit_module(self, module_path: Path):
+        self.audited.append(module_path)
+        return self._violations
+
+
+def test_collect_philosophy_violations_aggregates(tmp_path):
+    module = tmp_path / "module.py"
+    module.write_text("def sample():\n    pass\n")
+
+    violations = [
+        Violation(principle="module_docstring", message="Missing", line=1),
+        Violation(principle="module_docstring", message="Missing", line=1),
+        Violation(principle="public_api_documentation", message="Doc", line=2),
+    ]
+
+    auditor = DummyAuditor(violations)
+
+    summaries = collect_philosophy_violations([module], auditor=auditor)
+
+    assert auditor.audited == [module]
+    assert summaries["module_docstring"].count == 2
+    assert any("module.py" in example for example in summaries["module_docstring"].examples)
+    assert summaries["public_api_documentation"].count == 1
+
+
+def test_collect_color_token_report_identifies_orphans(tmp_path):
+    tokens_path = tmp_path / "lantern_tokens.json"
+    tokens_path.write_text(
+        json.dumps(
+            {
+                "tokens": {
+                    "color": {
+                        "brand": {
+                            "active": {"value": "#112233"},
+                            "idle": {"value": "#445566"},
+                        }
+                    }
+                }
+            }
+        )
+    )
+
+    css_file = tmp_path / "example.css"
+    css_file.write_text(".button { color: #112233; }")
+
+    report = collect_color_token_report(tokens_path)
+
+    assert {usage.token for usage in report.tokens} == {"active", "idle"}
+    orphan_tokens = {usage.token for usage in report.orphans}
+    assert orphan_tokens == {"idle"}
+    active_usage = next(usage for usage in report.tokens if usage.token == "active")
+    assert active_usage.used_in == ["example.css"]


### PR DESCRIPTION
## Summary
- add `decision_decay_dashboard.py` CLI that surfaces expiring temporal contracts, philosophy audit summaries, and orphan brand colors with optional JSON export
- implement collectors for `valid_until` decorators, `CodebasePhilosophyAuditor` results, and Lantern color token usage in deliverables
- document the dashboard in the README and cover collectors with focused unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcf58120ac832a8fc08bc6b850f7e7