### PR TITLE
Add Lantern logo raster regression guard script

### DIFF
--- a/09_Client_Deliverables/Lantern_Logo_Implementation_Kit/README.md
+++ b/09_Client_Deliverables/Lantern_Logo_Implementation_Kit/README.md
@@ -8,6 +8,7 @@ This package mirrors the Lantern component specification so designers and engine
 - `gradient_composer.js` — Utility that composes gradients from primitive tokens and warns when custom stops bypass the palette guardrails.
 - `lantern_logo.css` — Web starter styles illustrating how to compose semantic CSS variables, responsive padding, and hover affordances from the primitive token set.
 - `lantern_logo.svg` — Accessibility-ready master mark that consumes the token variables, exposes the gradient definition, and preserves the vessel and flame geometry described in the component spec.
+- `lantern_pixel_guard.py` — Palette-aware comparison utility for verifying that raster exports retain the expected pixel art characteristics.
 
 For governance details, geometry rules, and motion guidance, reference `../../08_Documentation/lantern_logo_component_spec.md`.
 
@@ -18,3 +19,18 @@ For governance details, geometry rules, and motion guidance, reference `../../08
 - The accompanying `gradient_composer.js` helper surfaces console warnings whenever gradient stops fall back to ad-hoc hex values. Call `composeGradient([{ position: 0, color: '{color.brand.azure}' }, …])` to receive a CSS-ready gradient string while automatically mapping references to their corresponding custom properties.
 
 > **Caution:** Always update or extend the primitive color tokens before adjusting gradient definitions, and avoid hard-coding new hexadecimal values directly into gradient tokens or SVG assets.
+
+## Raster regression guardrails
+
+When exporting PNG variants (e.g., `lantern_logo.png` and `lantern_final.png`) run:
+
+```bash
+python lantern_pixel_guard.py lantern_logo.png lantern_final.png \
+  --diff lantern_diff.png --max-pixel-change 12 --max-color-delta 0
+```
+
+The script mirrors the manual ImageMagick/Pillow checks brand ops uses by reporting
+color-count deltas, max channel differences, and generating a diff visualization.
+Failing thresholds exit with status code `1` so CI pipelines can block unexpected
+palette drift. Use `--json metrics.json` to archive the measurements alongside asset
+approvals.

--- a/09_Client_Deliverables/Lantern_Logo_Implementation_Kit/lantern_pixel_guard.py
+++ b/09_Client_Deliverables/Lantern_Logo_Implementation_Kit/lantern_pixel_guard.py
@@ -1,0 +1,220 @@
+"""Utilities to compare Lantern logo raster assets.
+
+The brand team frequently exports the vector master to PNG before handing the
+files to vendors.  When we iterate on the pixel art rendition we want to be
+confident that the new image retains the limited palette and only introduces
+the intentional tweaks.  The helpers in this module replicate the quick
+ImageMagick/Pillow checks the design team usually runs by hand and wrap them in
+an easy to lint, dependency-light command line program.
+
+Example
+-------
+>>> python lantern_pixel_guard.py lantern_logo.png lantern_final.png \
+...     --diff lantern_diff.png --max-pixel-change 12
+Color count change: 12 -> 12 (Δ0)
+Changed pixels: 24 / 16384 (0.15%)
+Maximum channel delta: 9
+Mean channel delta: 0.02
+
+If any of the optional guard-rail arguments are exceeded the program exits with
+status code ``1`` so it can slot directly into CI pipelines.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+from PIL import Image, ImageChops
+
+
+@dataclass
+class ImageMetrics:
+    """Summary statistics for a raster comparison."""
+
+    original_colors: int
+    candidate_colors: int
+    changed_pixels: int
+    total_pixels: int
+    max_delta: int
+    mean_delta: float
+
+    @property
+    def color_delta(self) -> int:
+        return self.candidate_colors - self.original_colors
+
+    @property
+    def changed_ratio(self) -> float:
+        if self.total_pixels == 0:
+            return 0.0
+        return self.changed_pixels / self.total_pixels
+
+    def to_dict(self) -> dict[str, float]:
+        return {
+            "original_colors": self.original_colors,
+            "candidate_colors": self.candidate_colors,
+            "color_delta": self.color_delta,
+            "changed_pixels": self.changed_pixels,
+            "total_pixels": self.total_pixels,
+            "changed_ratio": self.changed_ratio,
+            "max_delta": self.max_delta,
+            "mean_delta": self.mean_delta,
+        }
+
+
+def _load_image(path: Path) -> Image.Image:
+    if not path.exists():
+        raise FileNotFoundError(f"Image not found: {path}")
+    return Image.open(path).convert("RGBA")
+
+
+def _count_colors(image: Image.Image) -> int:
+    data = np.array(image)
+    unique = np.unique(data.reshape(-1, data.shape[-1]), axis=0)
+    return int(unique.shape[0])
+
+
+def _compute_metrics(original: Image.Image, candidate: Image.Image) -> ImageMetrics:
+    if original.size != candidate.size:
+        raise ValueError(
+            "Images must share the same dimensions to compare palette and pixels"
+        )
+
+    original_colors = _count_colors(original)
+    candidate_colors = _count_colors(candidate)
+
+    original_arr = np.array(original, dtype=np.int16)
+    candidate_arr = np.array(candidate, dtype=np.int16)
+    deltas = np.abs(original_arr - candidate_arr)
+
+    max_delta = int(deltas.max(initial=0))
+    mean_delta = float(deltas.mean())
+
+    changed_mask = np.any(deltas > 0, axis=-1)
+    changed_pixels = int(np.count_nonzero(changed_mask))
+    total_pixels = int(original_arr.shape[0] * original_arr.shape[1])
+
+    return ImageMetrics(
+        original_colors=original_colors,
+        candidate_colors=candidate_colors,
+        changed_pixels=changed_pixels,
+        total_pixels=total_pixels,
+        max_delta=max_delta,
+        mean_delta=mean_delta,
+    )
+
+
+def _save_diff(original: Image.Image, candidate: Image.Image, destination: Path) -> None:
+    diff = ImageChops.difference(original, candidate)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    diff.save(destination)
+
+
+def _validate_thresholds(metrics: ImageMetrics, args: argparse.Namespace) -> Iterable[str]:
+    if args.max_pixel_change is not None and metrics.max_delta > args.max_pixel_change:
+        yield (
+            f"Maximum pixel delta {metrics.max_delta} exceeds"
+            f" --max-pixel-change {args.max_pixel_change}"
+        )
+    if args.max_color_count is not None and metrics.candidate_colors > args.max_color_count:
+        yield (
+            f"Candidate color count {metrics.candidate_colors} exceeds"
+            f" --max-color-count {args.max_color_count}"
+        )
+    if (
+        args.max_color_delta is not None
+        and metrics.color_delta > args.max_color_delta
+    ):
+        yield (
+            f"Color count delta {metrics.color_delta} exceeds"
+            f" --max-color-delta {args.max_color_delta}"
+        )
+
+
+def _print_metrics(metrics: ImageMetrics) -> None:
+    delta_symbol = f"Δ{metrics.color_delta:+d}" if metrics.color_delta else "Δ0"
+    print(
+        f"Color count change: {metrics.original_colors} ->"
+        f" {metrics.candidate_colors} ({delta_symbol})"
+    )
+    changed_percentage = metrics.changed_ratio * 100
+    print(
+        "Changed pixels:"
+        f" {metrics.changed_pixels} / {metrics.total_pixels}"
+        f" ({changed_percentage:.2f}%)"
+    )
+    print(f"Maximum channel delta: {metrics.max_delta}")
+    print(f"Mean channel delta: {metrics.mean_delta:.4f}")
+
+
+def _export_json(path: Path, metrics: ImageMetrics) -> None:
+    payload = metrics.to_dict()
+    path.write_text(json.dumps(payload, indent=2))
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("original", type=Path, help="Reference PNG asset")
+    parser.add_argument("candidate", type=Path, help="Updated PNG asset")
+    parser.add_argument(
+        "--diff",
+        type=Path,
+        default=None,
+        help="Optional path to write a channel-difference visualization",
+    )
+    parser.add_argument(
+        "--json", type=Path, default=None, help="Optional path to export metrics as JSON"
+    )
+    parser.add_argument(
+        "--max-pixel-change",
+        type=int,
+        default=None,
+        help="Fail if any channel delta exceeds this value",
+    )
+    parser.add_argument(
+        "--max-color-count",
+        type=int,
+        default=None,
+        help="Fail if the candidate image contains more unique colors",
+    )
+    parser.add_argument(
+        "--max-color-delta",
+        type=int,
+        default=None,
+        help="Fail if the color-count increase exceeds this delta",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    original = _load_image(args.original)
+    candidate = _load_image(args.candidate)
+
+    metrics = _compute_metrics(original, candidate)
+
+    if args.diff is not None:
+        _save_diff(original, candidate, args.diff)
+
+    if args.json is not None:
+        _export_json(args.json, metrics)
+
+    _print_metrics(metrics)
+
+    failures = list(_validate_thresholds(metrics, args))
+    if failures:
+        for message in failures:
+            print(f"ERROR: {message}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/tests/test_lantern_pixel_guard.py
+++ b/tests/test_lantern_pixel_guard.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("PIL.Image")
+from PIL import Image
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = (
+    ROOT
+    / "09_Client_Deliverables"
+    / "Lantern_Logo_Implementation_Kit"
+    / "lantern_pixel_guard.py"
+)
+
+
+def _write_png(path: Path, pixels: list[list[tuple[int, int, int, int]]]) -> None:
+    height = len(pixels)
+    width = len(pixels[0]) if height else 0
+    image = Image.new("RGBA", (width, height))
+    for y, row in enumerate(pixels):
+        for x, value in enumerate(row):
+            image.putpixel((x, y), value)
+    image.save(path)
+
+
+def test_metrics_and_diff(tmp_path: Path) -> None:
+    original = tmp_path / "lantern_logo.png"
+    candidate = tmp_path / "lantern_final.png"
+    diff = tmp_path / "lantern_diff.png"
+    metrics_json = tmp_path / "metrics.json"
+
+    _write_png(
+        original,
+        [
+            [(10, 10, 10, 255), (10, 10, 10, 255)],
+            [(10, 10, 10, 255), (40, 40, 40, 255)],
+        ],
+    )
+    _write_png(
+        candidate,
+        [
+            [(10, 10, 10, 255), (10, 10, 10, 255)],
+            [(22, 10, 10, 255), (40, 44, 40, 255)],
+        ],
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            str(original),
+            str(candidate),
+            "--diff",
+            str(diff),
+            "--json",
+            str(metrics_json),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    stdout = completed.stdout
+    assert "Color count change: 2 -> 3" in stdout
+    assert "Maximum channel delta:" in stdout
+
+    diff_image = Image.open(diff)
+    assert diff_image.getpixel((0, 0)) == (0, 0, 0, 0)
+    assert diff_image.getpixel((0, 1))[0] == 12  # delta on red channel
+
+    metrics = json.loads(metrics_json.read_text())
+    assert metrics["original_colors"] == 2
+    assert metrics["candidate_colors"] == 3
+    assert metrics["changed_pixels"] == 2
+
+
+def test_threshold_failure(tmp_path: Path) -> None:
+    original = tmp_path / "lantern_logo.png"
+    candidate = tmp_path / "lantern_final.png"
+
+    _write_png(
+        original,
+        [[(0, 0, 0, 255), (0, 0, 0, 255)]],
+    )
+    _write_png(
+        candidate,
+        [[(30, 0, 0, 255), (0, 0, 0, 255)]],
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            str(original),
+            str(candidate),
+            "--max-pixel-change",
+            "10",
+            "--max-color-delta",
+            "0",
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 1
+    assert "ERROR" in completed.stderr
+    assert "--max-pixel-change 10" in completed.stderr
+    assert "--max-color-delta 0" in completed.stderr


### PR DESCRIPTION
## Summary
- add a lantern_pixel_guard.py utility that compares PNG exports, tracks palette deltas, and optionally enforces thresholds
- document the raster regression workflow in the Lantern logo implementation kit
- exercise the new CLI with pytest coverage to ensure metrics, diff output, and failure modes behave as expected

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd52e3bf34832a9770e168cf2974c1