### PR TITLE
Add processing capability checks for luxury TIFF pipeline

### DIFF
--- a/luxury_tiff_batch_processor.py
+++ b/luxury_tiff_batch_processor.py
@@ -43,10 +43,21 @@ class ProcessingCapabilities:
         return True
 
     def assert_luxury_grade(self) -> None:
+        """
+        Validates that the processing environment meets luxury-grade requirements:
+        - 16-bit precision
+        - HDR capability
+        Raises LuxuryGradeException if requirements are not met.
+        """
         if self.bit_depth < 16:
             raise LuxuryGradeException(
                 "Material Response requires 16-bit precision. "
-                "Install tifffile for 16-bit TIFF processing support."
+                "Install tifffile to unlock quantum color depth."
+            )
+        if not self.hdr_capable:
+            raise LuxuryGradeException(
+                "Luxury-grade processing requires HDR capability. "
+                "Install tifffile or ensure your environment supports HDR."
             )
 
 

--- a/luxury_tiff_batch_processor.py
+++ b/luxury_tiff_batch_processor.py
@@ -26,6 +26,30 @@ except Exception:  # pragma: no cover - optional dependency
     tifffile = None
 
 
+class LuxuryGradeException(RuntimeError):
+    """Raised when the processing environment cannot meet luxury standards."""
+
+
+class ProcessingCapabilities:
+    def __init__(self) -> None:
+        self.bit_depth = 16 if tifffile else 8
+        self.hdr_capable = self._detect_hdr_support()
+
+    def _detect_hdr_support(self) -> bool:
+        """Best-effort check for HDR support given optional dependencies."""
+
+        if not tifffile:
+            return False
+        return True
+
+    def assert_luxury_grade(self) -> None:
+        if self.bit_depth < 16:
+            raise LuxuryGradeException(
+                "Material Response requires 16-bit precision. "
+                "Install tifffile to unlock quantum color depth."
+            )
+
+
 LOGGER = logging.getLogger("luxury_tiff_batch_processor")
 
 RESAMPLING_LANCZOS = getattr(Image, "Resampling", Image).LANCZOS

--- a/luxury_tiff_batch_processor.py
+++ b/luxury_tiff_batch_processor.py
@@ -46,7 +46,7 @@ class ProcessingCapabilities:
         if self.bit_depth < 16:
             raise LuxuryGradeException(
                 "Material Response requires 16-bit precision. "
-                "Install tifffile to unlock quantum color depth."
+                "Install tifffile for 16-bit TIFF processing support."
             )
 
 


### PR DESCRIPTION
## Summary
- introduce a LuxuryGradeException to represent unmet processing standards
- add a ProcessingCapabilities helper that verifies optional HDR support and enforces 16-bit precision

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de1c323cdc832a9a99164f096d3a82