### PR TITLE
Improve processing capability detection

### DIFF
--- a/luxury_tiff_batch_processor.py
+++ b/luxury_tiff_batch_processor.py
@@ -62,7 +62,7 @@ class ProcessingCapabilities:
         try:
             return bool(supports_hdr)
         except Exception:  # pragma: no cover - defensive fallback
-            return True
+            return False
 
     def assert_luxury_grade(self) -> None:
         """

--- a/tests/test_processing_capabilities.py
+++ b/tests/test_processing_capabilities.py
@@ -1,0 +1,56 @@
+import pytest
+
+pytest.importorskip("numpy")
+
+from luxury_tiff_batch_processor import LuxuryGradeException, ProcessingCapabilities
+
+
+class _StubTiffFile:
+    def __init__(self, *, supports_hdr=True, provide_writer=True):
+        self.supports_hdr = supports_hdr
+        if provide_writer:
+            self.imwrite = object()
+
+
+def test_capabilities_without_tifffile_dependency():
+    capabilities = ProcessingCapabilities(tifffile_module=None)
+
+    assert capabilities.bit_depth == 8
+    assert capabilities.hdr_capable is False
+
+    with pytest.raises(LuxuryGradeException):
+        capabilities.assert_luxury_grade()
+
+
+def test_capabilities_with_hdr_supporting_dependency():
+    capabilities = ProcessingCapabilities(tifffile_module=_StubTiffFile())
+
+    assert capabilities.bit_depth == 16
+    assert capabilities.hdr_capable is True
+
+    # No exception should be raised when the environment meets the requirements.
+    capabilities.assert_luxury_grade()
+
+
+def test_capabilities_detect_hdr_limitations():
+    capabilities = ProcessingCapabilities(
+        tifffile_module=_StubTiffFile(supports_hdr=False)
+    )
+
+    assert capabilities.bit_depth == 16
+    assert capabilities.hdr_capable is False
+
+    with pytest.raises(LuxuryGradeException):
+        capabilities.assert_luxury_grade()
+
+
+def test_capabilities_detect_writer_absence():
+    capabilities = ProcessingCapabilities(
+        tifffile_module=_StubTiffFile(provide_writer=False)
+    )
+
+    assert capabilities.bit_depth == 8
+    assert capabilities.hdr_capable is False
+
+    with pytest.raises(LuxuryGradeException):
+        capabilities.assert_luxury_grade()


### PR DESCRIPTION
## Summary
- allow `ProcessingCapabilities` to accept injected tifffile modules and improve detection of 16-bit and HDR support
- add regression tests that exercise capability detection paths with and without optional tifffile features

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68de1e3258bc832a92de6169c7fe804f