### PR TITLE
Add evolutionary checkpoint utility

### DIFF
--- a/evolutionary_checkpoint.py
+++ b/evolutionary_checkpoint.py
@@ -24,7 +24,7 @@ class EvolutionaryCheckpoint:
     horizon: date
     mutation_path: str
 
-    def evolve_or_alert(self, *, today: Optional[date] = None) -> str:
+    def evolve_or_alert(self, *, today: date | None = None) -> str:
         """Return guidance about whether evolution is required.
 
         Parameters

--- a/evolutionary_checkpoint.py
+++ b/evolutionary_checkpoint.py
@@ -1,0 +1,40 @@
+"""Evolutionary guardrails for the codebase's long-term trajectory."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class EvolutionaryCheckpoint:
+    """Represents an evolutionary deadline for a particular workflow.
+
+    The checkpoint keeps track of a *horizon* (a :class:`~datetime.date` after
+    which a migration must be pursued) and the ``mutation_path`` that should be
+    followed once the horizon has been crossed.
+
+    The :meth:`evolve_or_alert` method returns human readable guidance that can
+    be surfaced in dashboards or CI logs.  It also accepts an optional
+    ``today`` override to make the class simple to test without having to rely
+    on the ambient system clock.
+    """
+
+    horizon: date
+    mutation_path: str
+
+    def evolve_or_alert(self, *, today: Optional[date] = None) -> str:
+        """Return guidance about whether evolution is required.
+
+        Parameters
+        ----------
+        today:
+            Optional date to use instead of :func:`datetime.date.today`.  This
+            is primarily useful for deterministic testing.
+        """
+
+        reference_date = today or date.today()
+        if reference_date > self.horizon:
+            return f"EVOLUTION REQUIRED: Migrate to {self.mutation_path}"
+        return f"STABLE: Current form viable until {self.horizon.isoformat()}"

--- a/tests/test_evolutionary_checkpoint.py
+++ b/tests/test_evolutionary_checkpoint.py
@@ -1,0 +1,52 @@
+"""Tests for :mod:`evolutionary_checkpoint`."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from evolutionary_checkpoint import EvolutionaryCheckpoint
+
+
+def test_evolution_required_message_when_horizon_has_passed() -> None:
+    checkpoint = EvolutionaryCheckpoint(
+        horizon=date(2024, 1, 1), mutation_path="lux/v2/pipeline"
+    )
+
+    message = checkpoint.evolve_or_alert(today=date(2024, 1, 2))
+
+    assert message == "EVOLUTION REQUIRED: Migrate to lux/v2/pipeline"
+
+
+def test_evolution_not_required_message_when_within_horizon() -> None:
+    checkpoint = EvolutionaryCheckpoint(
+        horizon=date(2024, 1, 10), mutation_path="lux/v3/pipeline"
+    )
+
+    message = checkpoint.evolve_or_alert(today=date(2024, 1, 5))
+
+    assert (
+        message
+        == "STABLE: Current form viable until 2024-01-10"
+    )
+
+
+class _FrozenDate(date):
+    """Helper date that lets us control :func:`date.today`."""
+
+    @classmethod
+    def today(cls) -> "_FrozenDate":
+        return cls(2024, 1, 9)
+
+
+def test_today_defaults_to_current_date(monkeypatch: pytest.MonkeyPatch) -> None:
+    checkpoint = EvolutionaryCheckpoint(
+        horizon=date(2024, 1, 10), mutation_path="lux/v3/pipeline"
+    )
+
+    monkeypatch.setattr("evolutionary_checkpoint.date", _FrozenDate)
+
+    message = checkpoint.evolve_or_alert()
+
+    assert message == "STABLE: Current form viable until 2024-01-10"


### PR DESCRIPTION
## Summary
- add an EvolutionaryCheckpoint helper that reports when migrations are due
- support overriding the current date to simplify deterministic testing
- cover the helper with targeted unit tests

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68de1ff31e40832aa974ca70d0b54084