### PR TITLE
Add MaterialResponseValidator with Fourier and fractal heuristics

### DIFF
--- a/material_response.py
+++ b/material_response.py
@@ -301,7 +301,13 @@ class MaterialResponseValidator:
         energy_after = np.sum(np.abs(fft_after) ** 2 * band_mask)
 
         if np.isclose(energy_before, 0.0):
-            return 1.0 if np.isclose(energy_after, 0.0) else float("inf")
+            if np.isclose(energy_after, 0.0):
+                return 1.0
+            else:
+                raise ValueError(
+                    "Cannot compute Fourier energy ratio: energy_before is zero but energy_after is not. "
+                    f"energy_before={energy_before}, energy_after={energy_after}, band={band}"
+                )
 
         return float(energy_after / energy_before)
 

--- a/material_response.py
+++ b/material_response.py
@@ -312,15 +312,27 @@ class MaterialResponseValidator:
         return float(energy_after / energy_before)
 
     @staticmethod
-    def _frequency_band_mask(shape: Sequence[int], band: str) -> np.ndarray:
-        """Return a boolean mask isolating the requested frequency band."""
+    def _frequency_band_mask(
+        shape: Sequence[int], 
+        band: str, 
+        cutoff: float = None
+    ) -> np.ndarray:
+        """
+        Return a boolean mask isolating the requested frequency band.
+
+        By default, the median radial frequency is used as the cutoff to separate
+        high and low frequency bands. This provides a balanced split for typical
+        material textures, but can be overridden by specifying the `cutoff`
+        parameter.
+        """
 
         grids = np.meshgrid(
             *[np.fft.fftfreq(n, d=1.0) for n in shape],
             indexing="ij",
         )
         radial_freq = np.sqrt(np.sum(np.square(grids), axis=0))
-        cutoff = np.median(radial_freq)
+        if cutoff is None:
+            cutoff = np.median(radial_freq)
 
         if band == "high":
             return radial_freq >= cutoff


### PR DESCRIPTION
## Summary
- add a MaterialResponseValidator that measures specular preservation and texture dimensionality
- implement Fourier band energy ratio and box-counting helpers to support the validator

## Testing
- pytest tests/test_processing_capabilities.py -k "Material" -q

------
https://chatgpt.com/codex/tasks/task_e_68de21173728832a8dfcbc534fa863c2