### PR TITLE
Handle non-numeric durations in probe summary

### DIFF
--- a/luxury_video_master_grader.py
+++ b/luxury_video_master_grader.py
@@ -229,7 +229,6 @@ def summarize_probe(data: Dict[str, object]) -> str:
     audio = next((s for s in streams if s.get("codec_type") == "audio"), {})
     pieces = []
     if duration:
-        numeric_duration: Optional[float]
         try:
             numeric_duration = float(duration)
         except (TypeError, ValueError):

--- a/luxury_video_master_grader.py
+++ b/luxury_video_master_grader.py
@@ -229,7 +229,13 @@ def summarize_probe(data: Dict[str, object]) -> str:
     audio = next((s for s in streams if s.get("codec_type") == "audio"), {})
     pieces = []
     if duration:
-        pieces.append(f"duration {float(duration):.2f}s")
+        numeric_duration: Optional[float]
+        try:
+            numeric_duration = float(duration)
+        except (TypeError, ValueError):
+            numeric_duration = None
+        if numeric_duration is not None and math.isfinite(numeric_duration):
+            pieces.append(f"duration {numeric_duration:.2f}s")
     if video:
         w = video.get("width")
         h = video.get("height")

--- a/tests/test_luxury_video_master_grader.py
+++ b/tests/test_luxury_video_master_grader.py
@@ -392,6 +392,28 @@ def test_summarize_probe_ignores_non_descriptive_color_tags():
     assert "trc=" not in summary
 
 
+@documents("Metadata summaries gracefully skip unusable duration fields")
+def test_summarize_probe_skips_non_numeric_duration():
+    probe = {
+        "format": {"duration": "N/A"},
+        "streams": [
+            {
+                "codec_type": "video",
+                "codec_name": "h264",
+                "width": 1920,
+                "height": 1080,
+                "avg_frame_rate": "30000/1001",
+                "r_frame_rate": "30000/1001",
+            }
+        ],
+    }
+
+    summary = summarize_probe(probe)
+
+    assert "duration" not in summary
+    assert "video h264 1920x1080" in summary
+
+
 @documents("CLI enforces required IO to prevent silent misfires")
 def test_parse_arguments_requires_input_and_output(capsys):
     with pytest.raises(SystemExit) as exc:


### PR DESCRIPTION
## Summary
- guard probe duration parsing so non-numeric values are ignored
- add a regression test confirming summaries skip unusable duration metadata

## Testing
- `pytest tests/test_luxury_video_master_grader.py`


------
https://chatgpt.com/codex/tasks/task_e_68de2cb2a5c8832a98125e0d9b5589ca