### PR TITLE
Handle missing ffprobe durations

### DIFF
--- a/luxury_video_master_grader.py
+++ b/luxury_video_master_grader.py
@@ -221,6 +221,20 @@ def probe_source(path: Path) -> Dict[str, object]:
         raise RuntimeError("Unable to parse ffprobe output") from exc
 
 
+def _parse_probe_duration(raw: object) -> Optional[float]:
+    """Return a finite float duration from ffprobe metadata when possible."""
+
+    if raw in (None, ""):
+        return None
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(value):
+        return None
+    return value
+
+
 def summarize_probe(data: Dict[str, object]) -> str:
     fmt = data.get("format", {})
     duration = fmt.get("duration")
@@ -228,13 +242,9 @@ def summarize_probe(data: Dict[str, object]) -> str:
     video = next((s for s in streams if s.get("codec_type") == "video"), {})
     audio = next((s for s in streams if s.get("codec_type") == "audio"), {})
     pieces = []
-    if duration:
-        try:
-            numeric_duration = float(duration)
-        except (TypeError, ValueError):
-            numeric_duration = None
-        if numeric_duration is not None and math.isfinite(numeric_duration):
-            pieces.append(f"duration {numeric_duration:.2f}s")
+    numeric_duration = _parse_probe_duration(duration)
+    if numeric_duration is not None:
+        pieces.append(f"duration {numeric_duration:.2f}s")
     if video:
         w = video.get("width")
         h = video.get("height")

--- a/tests/test_luxury_video_master_grader.py
+++ b/tests/test_luxury_video_master_grader.py
@@ -30,6 +30,23 @@ summarize_probe = MODULE.summarize_probe
 parse_arguments = MODULE.parse_arguments
 
 
+@pytest.fixture
+def probe_with_unknown_duration() -> dict:
+    return {
+        "format": {"duration": "N/A"},
+        "streams": [
+            {
+                "codec_type": "video",
+                "codec_name": "h264",
+                "width": 1920,
+                "height": 1080,
+                "avg_frame_rate": "30000/1001",
+                "r_frame_rate": "30000/1001",
+            }
+        ],
+    }
+
+
 @documents("Operator judgment can override sensing when continuity demands")
 def test_assess_frame_rate_respects_user_override():
     probe = {"streams": [{"codec_type": "video"}]}
@@ -393,22 +410,8 @@ def test_summarize_probe_ignores_non_descriptive_color_tags():
 
 
 @documents("Metadata summaries gracefully skip unusable duration fields")
-def test_summarize_probe_skips_non_numeric_duration():
-    probe = {
-        "format": {"duration": "N/A"},
-        "streams": [
-            {
-                "codec_type": "video",
-                "codec_name": "h264",
-                "width": 1920,
-                "height": 1080,
-                "avg_frame_rate": "30000/1001",
-                "r_frame_rate": "30000/1001",
-            }
-        ],
-    }
-
-    summary = summarize_probe(probe)
+def test_summarize_probe_skips_non_numeric_duration(probe_with_unknown_duration):
+    summary = summarize_probe(probe_with_unknown_duration)
 
     assert "duration" not in summary
     assert "video h264 1920x1080" in summary


### PR DESCRIPTION
## Summary
- add a dedicated helper to parse ffprobe durations defensively before building CLI summaries
- ensure summarize_probe omits duration output when parsing fails
- add a pytest fixture exercising ffprobe metadata with an "N/A" duration entry

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de2b792c30832ab3bacb2a4343092b