### PR TITLE
Add Mapping typing import for material_response

### DIFF
--- a/material_response.py
+++ b/material_response.py
@@ -13,7 +13,7 @@ from collections.abc import Sequence as SequenceABC
 from dataclasses import dataclass
 import math
 import re
-from typing import Dict, Iterable, List, Sequence, Tuple
+from typing import Dict, Iterable, List, Mapping, Sequence, Tuple
 
 
 def _is_sequence(value: object) -> bool:


### PR DESCRIPTION
## Summary
- add the missing `Mapping` type to the typing imports in `material_response.py`

## Testing
- flake8 *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df4431e504832abafd7d4148c1acf6