### PR TITLE
Normalize cultural background aliases in material response

### DIFF
--- a/material_response.py
+++ b/material_response.py
@@ -9,6 +9,7 @@ reference.  This module provides such an artefact.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from collections.abc import Sequence as SequenceABC
 from dataclasses import dataclass
 import math

--- a/material_response.py
+++ b/material_response.py
@@ -462,13 +462,24 @@ class GlobalLuxurySemantics:
         "middle eastern": {"awe": 0.08, "comfort": 0.04},
         "american": {"focus": 0.03, "comfort": 0.02},
     }
+    _CULTURAL_ALIAS_MAP: Mapping[str, str] = {
+        "med": "mediterranean",
+        "mediterranean coast": "mediterranean",
+        "scandi": "scandinavian",
+        "nordic": "scandinavian",
+        "jp": "japanese",
+        "levantine": "middle eastern",
+        "us": "american",
+        "usa": "american",
+    }
 
     def recontextualize(
         self, material: MaterialAestheticProfile, resonance: EmotionalResonance
     ) -> ContextualResonance:
         """Return resonance tuned to cultural and material narratives."""
 
-        background = resonance.cultural_background.lower()
+        background_key = resonance.cultural_background.strip().lower()
+        background = self._CULTURAL_ALIAS_MAP.get(background_key, background_key)
         weights = self._CULTURAL_WEIGHTS.get(background, {})
 
         awe = _clamp(resonance.awe + weights.get("awe", 0.0) + 0.12 * material.rarity)

--- a/tests/test_cognitive_material_response.py
+++ b/tests/test_cognitive_material_response.py
@@ -49,6 +49,28 @@ def test_global_luxury_semantics_reacts_to_culture() -> None:
     assert "scandinavian" in contextualized.narrative
 
 
+def test_global_luxury_semantics_alias_normalization() -> None:
+    material = MaterialAestheticProfile(
+        name="Lacquered Shoji",
+        texture="lacquer and rice paper",
+        rarity=0.65,
+        craftsmanship=0.85,
+        innovation=0.42,
+    )
+    resonance = EmotionalResonance(
+        awe=0.62,
+        comfort=0.51,
+        focus=0.58,
+        cultural_background="Nordic",
+    )
+
+    semantics = GlobalLuxurySemantics()
+    contextualized = semantics.recontextualize(material, resonance)
+
+    assert "scandinavian" in contextualized.narrative
+    assert contextualized.scores["focus"] >= contextualized.scores["comfort"]
+
+
 def test_cognitive_material_response_pipeline() -> None:
     material = MaterialAestheticProfile(
         name="Midnight Velvet Chaise",


### PR DESCRIPTION
## Summary
- normalize cultural background inputs in GlobalLuxurySemantics with an alias map
- add coverage ensuring Nordic aliases resolve to the Scandinavian narrative

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df4421e138832a93e0105174b6903f