### PR TITLE
Validate clamp bounds before applying limits

### DIFF
--- a/material_response.py
+++ b/material_response.py
@@ -287,6 +287,12 @@ def _extract_keywords(text: str) -> List[str]:
 def _clamp(value: float, minimum: float = 0.0, maximum: float = 1.0) -> float:
     """Return ``value`` limited to the inclusive ``[minimum, maximum]`` range."""
 
+    if minimum > maximum:
+        raise ValueError(
+            "minimum cannot be greater than maximum: "
+            f"minimum={minimum!r}, maximum={maximum!r}"
+        )
+
     return max(minimum, min(maximum, value))
 
 

--- a/tests/test_material_response.py
+++ b/tests/test_material_response.py
@@ -1,0 +1,12 @@
+"""Tests for helpers inside :mod:`material_response`."""
+
+import pytest
+
+from material_response import _clamp
+
+
+def test_clamp_raises_when_minimum_exceeds_maximum() -> None:
+    """Ensure invalid clamp bounds raise a :class:`ValueError`."""
+
+    with pytest.raises(ValueError):
+        _clamp(0.5, minimum=0.8, maximum=0.2)


### PR DESCRIPTION
## Summary
- ensure `_clamp` rejects inverted ranges by raising a ValueError before computing the bounds
- add a regression test that exercises the new guard to keep the behaviour stable

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68df50b0b1c4832a870cc00ee7bf9eeb