### PR TITLE
Ensure Mapping annotation available for Flake8

### DIFF
--- a/material_response.py
+++ b/material_response.py
@@ -9,7 +9,6 @@ reference.  This module provides such an artefact.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 from collections.abc import Sequence as SequenceABC
 from dataclasses import dataclass
 import math


### PR DESCRIPTION
## Summary
- rely on the typing version of Mapping so module-level annotations resolve during linting

## Testing
- flake8 material_response.py --count --select=E9,F63,F7,F82 --show-source --statistics

------
https://chatgpt.com/codex/tasks/task_e_68df533a4248832a8b647478a4c3bfc8