### PR TITLE
Configure Dependabot for pip and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,11 @@
 
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
## Summary
- configure Dependabot to monitor pip dependencies in the repository root
- add weekly update checks for GitHub Actions workflows

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df56758ef4832a8e88709cfaabd519