### PR TITLE
Handle zero reference energy in specular ratio

### DIFF
--- a/material_response.py
+++ b/material_response.py
@@ -788,12 +788,7 @@ class MaterialResponseValidator:
         energy_after = _energy_by_band(dft_after, band, cutoff, radii)
 
         if math.isclose(energy_before, 0.0, rel_tol=1e-9, abs_tol=1e-12):
-            if math.isclose(energy_after, 0.0, rel_tol=1e-9, abs_tol=1e-12):
-                return 1.0
-            raise ValueError(
-                "Cannot compute Fourier energy ratio: energy_before is zero but energy_after is not. "
-                f"energy_before={energy_before}, energy_after={energy_after}, band={band}"
-            )
+            return 1.0
 
         return float(energy_after / energy_before)
 

--- a/tests/test_material_response.py
+++ b/tests/test_material_response.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from material_response import _clamp
+from material_response import MaterialResponseValidator, _clamp
 
 
 def test_clamp_raises_when_minimum_exceeds_maximum() -> None:
@@ -10,3 +10,15 @@ def test_clamp_raises_when_minimum_exceeds_maximum() -> None:
 
     with pytest.raises(ValueError):
         _clamp(0.5, minimum=0.8, maximum=0.2)
+
+
+def test_specular_preservation_returns_unity_when_reference_energy_is_zero() -> None:
+    """Regression test ensuring zero-reference energies return a neutral ratio."""
+
+    validator = MaterialResponseValidator()
+    before = [[0.0, 0.0], [0.0, 0.0]]
+    after = [[0.0, 1.0], [2.0, 3.0]]
+
+    result = validator.measure_specular_preservation(before, after)
+
+    assert result == pytest.approx(1.0)


### PR DESCRIPTION
## Summary
- ensure the Fourier energy ratio helper returns 1.0 whenever the reference energy is effectively zero
- add a regression test covering a zero baseline with non-zero post-treatment energy

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df5b712c54832a9ac572567407b002