### PR TITLE
Prevent input/output directory conflicts in TIFF batch processor

### DIFF
--- a/luxury_tiff_batch_processor.py
+++ b/luxury_tiff_batch_processor.py
@@ -855,6 +855,24 @@ def run_pipeline(args: argparse.Namespace) -> int:
     if not input_root.exists() or not input_root.is_dir():
         raise SystemExit(f"Input folder '{input_root}' does not exist or is not a directory")
 
+    def _contains(parent: Path, child: Path) -> bool:
+        try:
+            child.relative_to(parent)
+        except ValueError:
+            return False
+        return True
+
+    if input_root == output_root:
+        raise SystemExit("Output folder must be different from the input folder to avoid self-overwrites.")
+    if _contains(input_root, output_root):
+        raise SystemExit(
+            "Output folder cannot be located inside the input folder; choose a sibling or separate directory."
+        )
+    if _contains(output_root, input_root):
+        raise SystemExit(
+            "Input folder cannot be located inside the output folder; choose non-overlapping directories."
+        )
+
     adjustments = build_adjustments(args)
     images = sorted(collect_images(input_root, args.recursive))
     if not images:

--- a/tests/test_luxury_tiff_batch_processor.py
+++ b/tests/test_luxury_tiff_batch_processor.py
@@ -148,6 +148,32 @@ def test_parse_args_sets_default_output(tmp_path: Path):
     assert args.output == input_dir.parent / "SV-Stills_lux"
 
 
+def test_run_pipeline_rejects_nested_output(tmp_path: Path):
+    input_dir = tmp_path / "input"
+    nested_output = input_dir / "lux"
+    nested_output.mkdir(parents=True)
+
+    args = ltiff.parse_args([str(input_dir), str(nested_output)])
+
+    with pytest.raises(SystemExit) as excinfo:
+        ltiff.run_pipeline(args)
+
+    assert "Output folder cannot be located inside the input folder" in str(excinfo.value)
+
+
+def test_run_pipeline_rejects_input_nested_in_output(tmp_path: Path):
+    output_dir = tmp_path / "output"
+    input_dir = output_dir / "input"
+    input_dir.mkdir(parents=True)
+
+    args = ltiff.parse_args([str(input_dir), str(output_dir)])
+
+    with pytest.raises(SystemExit) as excinfo:
+        ltiff.run_pipeline(args)
+
+    assert "Input folder cannot be located inside the output folder" in str(excinfo.value)
+
+
 @documents("User overrides cascade atop curated presets without drift")
 def test_build_adjustments_applies_overrides(tmp_path):
     args = ltiff.parse_args(


### PR DESCRIPTION
## Summary
- add guards to the TIFF batch processor to detect when the input and output directories overlap
- cover the new conflict detection logic with focused unit tests

## Testing
- pytest tests/test_luxury_tiff_batch_processor.py

------
https://chatgpt.com/codex/tasks/task_e_68df7ef177c0832ab7e606ffe5ebf5b1