### PR TITLE
Enhance material response finishing heuristics

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,22 @@ python lux_render_pipeline.py \
   --width 1536 --height 864 \
   --steps 35 --strength 0.42 --gs 8.2 \
   --material-response --texture-boost 0.28 --ambient-occlusion 0.14 --highlight-warmth 0.1 --haze-strength 0.08 \
+  --floor-plank-contrast 0.16 --floor-specular 0.22 --textile-contrast 0.24 \
+  --leather-sheen 0.18 --fireplace-glow 0.26 --fireplace-glow-radius 60 \
+  --window-reflection 0.18 \
   --no-depth
 ```
 
 Pair the result with the TIFF batch processor below for final client delivery.
+
+Material Response finishing now maps common interior materials to targeted
+micro-responses:
+
+- **Floor plank contrast / specular** – reinforces oak grain variation, plank seams, and directional highlights flowing from the windows.
+- **Textile contrast** – separates linens, duvets, and throws with nuanced wrinkle shading so bedding reads tactile rather than plastic.
+- **Leather sheen** – restores supple specular roll-off on benches and accent seating.
+- **Fireplace glow** – diffuses a warm gradient from the flame box onto adjacent floors and walls for believable integration.
+- **Window reflection** – projects soft mullion reflections and light spill onto the flooring while respecting ambient occlusion.
 
 ## Luxury TIFF Batch Processor
 The repository now includes `luxury_tiff_batch_processor.py`, a high-end batch workflow for polishing large-format TIFF photography prior to digital launch. The script preserves metadata, honors 16-bit source files when [`tifffile`](https://pypi.org/project/tifffile/) is available, and layers tonal, chroma, clarity, and diffusion refinements tuned for ultra-luxury real-estate storytelling.


### PR DESCRIPTION
## Summary
- add targeted material response refinements for flooring, textiles, leather, fireplace glow, and window reflections
- expose new CLI parameters so the rendering pipeline can control the expanded finishing pass
- update the README example and documentation to highlight the new adjustments

## Testing
- pytest tests/test_material_response.py

------
https://chatgpt.com/codex/tasks/task_e_68e0a6cb41b8832a8e71d2a41d606a27