### PR TITLE
Add configurable floor contact shadow mask

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,10 @@ python lux_render_pipeline.py \
   --steps 35 --strength 0.42 --gs 8.2 \
   --material-response --texture-boost 0.28 --ambient-occlusion 0.14 --highlight-warmth 0.1 --haze-strength 0.08 \
   --floor-plank-contrast 0.16 --floor-specular 0.22 --textile-contrast 0.24 \
+  --floor-contact-shadow 0.06 \
   --leather-sheen 0.18 --fireplace-glow 0.26 --fireplace-glow-radius 60 \
-  --window-reflection 0.18 \
+  --window-reflection 0.18 --bedding-relief 0.22 --wall-texture 0.14 \
+  --painting-integration 0.16 --window-light-wrap 0.2 --exterior-atmosphere 0.18 \
   --no-depth
 ```
 
@@ -67,10 +69,16 @@ Material Response finishing now maps common interior materials to targeted
 micro-responses:
 
 - **Floor plank contrast / specular** – reinforces oak grain variation, plank seams, and directional highlights flowing from the windows.
+- **Floor contact shadow** – feathers a grounded penumbra at the floor transition even when global ambient occlusion is gentle.
 - **Textile contrast** – separates linens, duvets, and throws with nuanced wrinkle shading so bedding reads tactile rather than plastic.
 - **Leather sheen** – restores supple specular roll-off on benches and accent seating.
 - **Fireplace glow** – diffuses a warm gradient from the flame box onto adjacent floors and walls for believable integration.
 - **Window reflection** – projects soft mullion reflections and light spill onto the flooring while respecting ambient occlusion.
+- **Bedding relief** – adds micro-wrinkle contrast and fold occlusion so duvets, throws, and pillows feel dimensional.
+- **Wall texture** – injects subtle plaster/builder noise into bright painted surfaces so walls avoid a CG-flat read.
+- **Painting integration** – pulls wall art into the room's lighting with rim glow and soft shadow falloff.
+- **Window light wrap** – feathers panoramic daylight across floor, bed, and bench for cohesive lighting.
+- **Exterior atmosphere** – harmonizes the exterior vista with interior haze for believable depth continuity.
 
 ## Luxury TIFF Batch Processor
 The repository now includes `luxury_tiff_batch_processor.py`, a high-end batch workflow for polishing large-format TIFF photography prior to digital launch. The script preserves metadata, honors 16-bit source files when [`tifffile`](https://pypi.org/project/tifffile/) is available, and layers tonal, chroma, clarity, and diffusion refinements tuned for ultra-luxury real-estate storytelling.


### PR DESCRIPTION
## Summary
- add a configurable floor contact shadow blend ahead of the ambient occlusion pass to provide grounded transitions even when AO is low
- reuse the precomputed floor transition mask for ambient occlusion and surface adjustments
- expose the new control through the CLI/FinishConfig and document it in the Material Response workflow

## Testing
- python -m compileall lux_render_pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68e0a8ff3224832ab9105e75756904da