### PR TITLE
Cleanup README merge duplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,12 @@ A cutting-edge collection of **16 professional color grading LUTs** featuring in
 - [Collection Contents](#collection-contents)
 - [Innovation](#innovation)
 - [Usage](#usage)
+    - [Material Response Finishing for Neural Renders](#material-response-finishing-for-neural-renders)
 - [Luxury TIFF Batch Processor](#luxury-tiff-batch-processor)
     - [TIFF Batch Processor Key Features](#tiff-batch-processor-key-features)
     - [TIFF Batch Processor Requirements](#tiff-batch-processor-requirements)
     - [TIFF Batch Processor Example](#tiff-batch-processor-example)
+    - [Staying Synchronized With `main`](#staying-synchronized-with-main)
 - [Luxury Video Master Grader](#luxury-video-master-grader)
     - [Luxury Video Master Grader Key Features](#luxury-video-master-grader-key-features)
     - [Luxury Video Master Grader Requirements](#luxury-video-master-grader-requirements)
@@ -100,21 +102,6 @@ The repository now includes `luxury_tiff_batch_processor.py`, a high-end batch w
 > **Note:** Earlier revisions triggered `F821` undefined-name lint errors. Pull the latest main branch (or reinstall from the freshest ZIP) to ensure you have the corrected helper that resolves the NumPy dtype handling.
 
 ### Example (TIFF Batch Processor)
-
-### Staying Synchronized With `main`
-To keep feature branches review-ready, regularly reconcile them with the newest
-`main` history:
-
-1. `git fetch origin`
-2. `git checkout main`
-3. `git pull`
-4. `git checkout <your-branch>`
-5. `git merge origin/main` *(or `git rebase origin/main` if you prefer a linear history)*
-
-Resolve any conflicts, rerun your tests, then push the refreshed branch. GitHub
-will report `behind 0` once these steps are complete.
-
-### TIFF Batch Processor Example
 ```bash
 python luxury_tiff_batch_processor.py /path/to/raw_tiffs /path/to/output \
   --preset signature --resize-long-edge 7000 --overwrite
@@ -145,6 +132,19 @@ will mirror the processed files in `/Users/rc/Downloads/Montecito-Shores-2/SV-St
 Override any preset control (exposure, midtone contrast, vibrance, clarity, glow, etc.)
 by providing the corresponding command-line flag. Use `--dry-run` to audit the processing
 plan without writing files, and `--recursive` to mirror nested shoot-day folders.
+
+### Staying Synchronized With `main`
+To keep feature branches review-ready, regularly reconcile them with the newest
+`main` history:
+
+1. `git fetch origin`
+2. `git checkout main`
+3. `git pull`
+4. `git checkout <your-branch>`
+5. `git merge origin/main` *(or `git rebase origin/main` if you prefer a linear history)*
+
+Resolve any conflicts, rerun your tests, then push the refreshed branch. GitHub
+will report `behind 0` once these steps are complete.
 
 ## Luxury Video Master Grader
 
@@ -210,95 +210,18 @@ Use `--custom-lut` to feed bespoke `.cube` files, tweak parameters such as `--co
   --aces-odt rec2020-pq --deband medium --halation strong --hdr10-metadata auto
 ```
 
-Layer the script after `luxury_video_master_grader.py` to apply bespoke LUTs before the
-HDR-specific finishing tools run. The pipeline preserves Dolby Vision and static HDR10
-metadata where available, while the deband and halation stages default to the Codex branch
-recipes highlighted in the documentation examples.
+Layer the script after `luxury_video_master_grader.py` to apply bespoke LUTs before the HDR-specific finishing tools run. The pipeline preserves Dolby Vision and static HDR10 metadata where available, while the deband and halation stages default to the Codex branch recipes highlighted in the documentation examples.
 
 ## Decision Decay Dashboard
 
-`decision_decay_dashboard.py` surfaces temporal contracts, codebase philosophy violations, and brand color token drift in a single terminal dashboard.
-It cross-references `tests/` for `@valid_until` decorators, audits Python sources with `CodebasePhilosophyAuditor`, and highlights unused color tokens
-from the Lantern logo deliverables so teams know what requires attention next.
+`decision_decay_dashboard.py` surfaces temporal contracts, codebase philosophy violations, and brand color token drift in a single terminal dashboard. It cross-references `tests/` for `@valid_until` decorators, audits Python sources with `CodebasePhilosophyAuditor`, and highlights unused color tokens from the Lantern logo deliverables so teams know what requires attention next.
 
 ### Running the dashboard
 ```bash
 python decision_decay_dashboard.py
 ```
 
-Use `--root` to audit a different project tree, `--tests` or `--tokens` to point at alternate assets, and `--json <path>` to export the findings for downstream
-automation. Near-term `valid_until` expirations are flagged in yellow when `rich` is installed (or with a `!` prefix in plain text). Philosophy violations are
-aggregated by principle with example file locations, while the color section lists which brand hex values are still unused in CSS/JS deliverables.
-
-## Luxury TIFF Batch Processor
-
-The repository now includes `luxury_tiff_batch_processor.py`, a high-end batch workflow
-for polishing large-format TIFF photography prior to digital launch. The script preserves
-metadata, honours 16-bit source files when [`tifffile`](https://pypi.org/project/tifffile/)
-is available, and layers tonal, chroma, clarity, and diffusion refinements tuned for
-ultra-luxury real-estate storytelling.
-
-### TIFF Processor Requirements
-
-- Python 3.11+
-- `pip install numpy pillow` (add `tifffile` for lossless 16-bit output)
-
-### Example
-
-```bash
-python luxury_tiff_batch_processor.py /path/to/raw_tiffs /path/to/output \
-  --preset signature --resize-long-edge 7000 --overwrite
-```
-
-Override any preset control (exposure, midtone contrast, vibrance, clarity, glow, etc.)
-by providing the corresponding command-line flag. Use `--dry-run` to audit the processing
-plan without writing files, and `--recursive` to mirror nested shoot-day folders.
-
-## Luxury Video Master Grader
-
-`luxury_video_master_grader.py` brings the same curated aesthetic to short-form motion
-content. It wraps FFmpeg with preset-driven LUT application, tasteful denoising, clarity
-and film-grain treatments, then exports a mezzanine-ready Apple ProRes master by default.
-The pipeline now auto-detects HDR transfers and tone-maps them into a refined BT.709
-space, optionally adds ultra-fine debanding and cinematic halation bloom, and keeps
-gradient-rich interiors spotless with updated presets.
-
-### Video Grader Requirements
-
-- FFmpeg 6+
-
-### Examples
-
-```bash
-# Inspect available looks and recipes
-python luxury_video_master_grader.py --list-presets
-
-# Grade a clip with the signature exterior look and generate a ProRes 422 HQ master
-python luxury_video_master_grader.py foyer.mov foyer_master.mov --preset signature_estate --overwrite
-
-# Apply the courtyard sunset preset, but intensify saturation and render a 240-frame preview
-python luxury_video_master_grader.py pool.mp4 pool_preview.mov \
-  --preset golden_hour_courtyard --saturation 1.2 --preview-frames 240 --dry-run
-
-# Force a master at 23.976fps if the source is variable frame rate
-python luxury_video_master_grader.py drone.mov drone_master.mov \
-  --target-fps 23.976 --overwrite
-
-# Manually invoke the advanced finishing pipeline on an HDR master
-python luxury_video_master_grader.py hdr.mov hdr_sdr_master.mov \
-  --tone-map hable --tone-map-peak 1200 --tone-map-desat 0.2 \
-  --deband strong --halation-intensity 0.18 --halation-radius 22
-```
-
-Use `--custom-lut` to feed bespoke `.cube` files, tweak parameters such as `--contrast`
-or `--grain`, layer in `--deband` smoothing or halation controls, and enable `--dry-run`
-to inspect the underlying FFmpeg command without
-rendering. The script automatically probes the source to surface resolution, frame-rate
-metadata and audio configuration before processing, then monitors for drift or variable
-frame-rate clips. When necessary it conforms delivery to the nearest cinema broadcast
-standard (or a user-specified `--target-fps`) to guarantee smooth, continuous playback.
-HDR clips are further analysed so the tool can apply tasteful tone mapping automatically,
-or respect explicit `--tone-map` overrides when you need a particular operator.
+Use `--root` to audit a different project tree, `--tests` or `--tokens` to point at alternate assets, and `--json <path>` to export the findings for downstream automation. Near-term `valid_until` expirations are flagged in yellow when `rich` is installed (or with a `!` prefix in plain text). Philosophy violations are aggregated by principle with example file locations, while the color section lists which brand hex values are still unused in CSS/JS deliverables.
 
 ## License
 


### PR DESCRIPTION
## Summary
- remove duplicate sections left over from a previous merge and restore a single source of truth for each workflow description in the README
- update the table of contents with links for the neural render finishing guidance and staying in sync instructions to match the cleaned sections

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e0b2971f68832a9bc102bb6a02e40b