### PR TITLE
Restore TIFF pipeline functions and fix conversions

### DIFF
--- a/tests/test_float_roundtrip.py
+++ b/tests/test_float_roundtrip.py
@@ -56,7 +56,7 @@ def test_image_to_float_roundtrip_signed_int_image():
     gradient = np.linspace(-5000, 5000, 49, dtype=np.int32).reshape(7, 7)
     image = Image.fromarray(gradient)
 
-    rgb_float, dtype, alpha = image_to_float(image)
+    rgb_float, dtype, alpha, _ = image_to_float(image)
 
     assert dtype == np.int32
     assert alpha is None


### PR DESCRIPTION
## Summary
- restore pipeline orchestration helpers so golden hour workflow hooks can call run_pipeline and process_single_image
- improve float/int round-tripping by tracking base channels, supporting signed data, and preserving tonal fidelity when saving
- refine vibrance logic and metadata sanitisation so resized TIFFs retain correct geometry and descriptive tags

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e0b4b27d50832a8f283fb92f772c6a