### PR TITLE
Allow ProcessingCapabilities to disable tifffile via None

### DIFF
--- a/luxury_tiff_batch_processor.py
+++ b/luxury_tiff_batch_processor.py
@@ -41,17 +41,24 @@ class LuxuryGradeException(RuntimeError):
 class ProcessingCapabilities:
     """Introspects optional dependencies to describe processing fidelity."""
 
-    def __init__(self, tifffile_module: Any | None = None) -> None:
+    _SENTINEL = object()
+
+    def __init__(self, tifffile_module: Any | None | object = _SENTINEL) -> None:
         """Initialise capability detection.
 
         Parameters
         ----------
         tifffile_module:
-            Optional dependency override primarily used by tests.  When ``None``
-            the globally imported :mod:`tifffile` module is consulted.
+            Optional dependency override primarily used by tests.  When omitted
+            (the default) the globally imported :mod:`tifffile` module is
+            consulted.  Passing ``None`` explicitly simulates the dependency not
+            being available at all.
         """
 
-        self._tifffile = tifffile_module if tifffile_module is not None else tifffile
+        if tifffile_module is self._SENTINEL:
+            self._tifffile = tifffile
+        else:
+            self._tifffile = tifffile_module
         self.bit_depth = 16 if self._supports_16_bit_output() else 8
         self.hdr_capable = self._detect_hdr_support()
 


### PR DESCRIPTION
## Summary
- ensure ProcessingCapabilities treats an explicit None override as the absence of tifffile
- describe the new override semantics in the class documentation

## Testing
- pytest tests/test_processing_capabilities.py::test_capabilities_without_tifffile_dependency

------
https://chatgpt.com/codex/tasks/task_e_68e0bc267948832ab1c4d10ab19082ad