### PR TITLE
Use shared helper when copying color metadata

### DIFF
--- a/luxury_video_master_grader.py
+++ b/luxury_video_master_grader.py
@@ -714,14 +714,14 @@ def build_filter_graph(config: Dict[str, object]) -> Tuple[str, str]:
 
 def determine_color_metadata(args: argparse.Namespace, probe: Dict[str, object]) -> tuple[Optional[str], Optional[str], Optional[str]]:
     """Determine color metadata based on priority: explicit > color-from-source > none."""
+
     # Priority 1: Explicit overrides
     if args.color_primaries or args.color_transfer or args.color_space:
         return args.color_primaries, args.color_transfer, args.color_space
 
     # Priority 2: Copy from source if requested
     if args.color_from_source:
-        streams = probe.get("streams", [])
-        video = next((s for s in streams if s.get("codec_type") == "video"), {})
+        video = extract_video_stream(probe)
         if video:
             primaries = normalise_color_tag(video.get("color_primaries"))
             transfer = normalise_color_tag(video.get("color_trc"))


### PR DESCRIPTION
## Summary
- reuse the existing extract_video_stream helper when copying metadata from the probe
- keep color tag normalisation logic unchanged while avoiding duplicate stream selection code

## Testing
- pytest tests/test_luxury_video_master_grader.py

------
https://chatgpt.com/codex/tasks/task_e_68e0c2e81d50832ab47a11f2c214ac6f