### PR TITLE
Improve TIFF float conversion pipeline and expose run_pipeline

### DIFF
--- a/tests/test_luxury_tiff_batch_processor.py
+++ b/tests/test_luxury_tiff_batch_processor.py
@@ -17,6 +17,11 @@ sys.path.append(str(Path(__file__).resolve().parent.parent))
 import luxury_tiff_batch_processor as ltiff
 
 
+def test_run_pipeline_exposed_in_dunder_all():
+    exported = getattr(ltiff, "__all__", ())
+    assert "run_pipeline" in exported
+
+
 def _saturation(rgb: np.ndarray) -> np.ndarray:
     maxc = rgb.max(axis=2)
     minc = rgb.min(axis=2)


### PR DESCRIPTION
## Summary
- preserve floating-point TIFF dynamic range by tracking per-channel normalisation metadata and reapplying it during export
- expose the processing entry point via `__all__` and enrich `image_to_float` with a structured result container
- add regression tests for float range round-trips and ensure `run_pipeline` is publicly exported

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e0c496c4e8832aabcc2208e2a21242