### PR TITLE
Remove undefined resize_target alias in TIFF processor

### DIFF
--- a/luxury_tiff_batch_processor.py
+++ b/luxury_tiff_batch_processor.py
@@ -1114,11 +1114,10 @@ def process_single_image(
                 arr, dtype, alpha, base_channels = float_result  # type: ignore[misc]
             float_norm = None
         adjusted = apply_adjustments(arr, adjustments)
-        resize_target = resize_long_edge
-        if resize_target is not None:
-            adjusted = resize_long_edge_array(adjusted, resize_target)
+        if resize_long_edge is not None:
+            adjusted = resize_long_edge_array(adjusted, resize_long_edge)
             if alpha is not None:
-                alpha = resize_long_edge_array(alpha, resize_target)
+                alpha = resize_long_edge_array(alpha, resize_long_edge)
         arr_int = float_to_dtype_array(
             adjusted,
             dtype,


### PR DESCRIPTION
## Summary
- use the existing `resize_long_edge` argument directly when resizing outputs instead of an undefined alias

## Testing
- flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
- pytest tests/test_luxury_tiff_batch_processor.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e0d387e5b8832aad89d07d2ee26f3a