### PR TITLE
Add pyproject metadata for dependency management

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -40,7 +40,10 @@ This repository contains a professional LUT (Look-Up Table) collection and video
 git clone https://github.com/RC219805/800-Picacho-Lane-LUTs.git
 cd 800-Picacho-Lane-LUTs
 
-# Install Python dependencies
+# Install Python dependencies (installs project metadata requirements)
+pip install .
+
+# Alternatively, mirror CI exactly
 pip install -r requirements.txt
 
 # Install development dependencies

--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ The repository now includes `luxury_tiff_batch_processor.py`, a high-end batch w
 
 ### TIFF Batch Processor Requirements
 - Python 3.11+
-- `pip install numpy pillow` (add `tifffile` for lossless 16-bit output)
+- Install dependencies with `pip install .` (or `pip install -r requirements.txt` to mirror CI).
+- Add `tifffile` for lossless 16-bit output.
 
 > **Note:** Earlier revisions triggered `F821` undefined-name lint errors. Pull the latest main branch (or reinstall from the freshest ZIP) to ensure you have the corrected helper that resolves the NumPy dtype handling.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["setuptools>=65"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "picacho-lane-luts"
+version = "0.1.0"
+description = "Luxury image and video processing toolkit with LUT collections."
+readme = "README.md"
+requires-python = ">=3.10"
+authors = [{ name = "RC219805" }]
+dependencies = [
+    "numpy>=1.24,<3",
+    "Pillow>=10.0.0,<12",
+]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: Other/Proprietary License",
+    "Operating System :: OS Independent",
+]
+
+[tool.setuptools.packages.find]
+where = ["."]
+exclude = ["tests*", "input_images", "processed_images"]


### PR DESCRIPTION
## Summary
- add a pyproject.toml so pip install . brings in Pillow and NumPy automatically
- update setup instructions to highlight installing through project metadata or requirements.txt

## Testing
- pytest tests/test_luxury_tiff_batch_processor.py

------
https://chatgpt.com/codex/tasks/task_e_68e15adbcf4c832ab89afe2f3688f28a