### PR TITLE
Add explicit return format selection for image_to_float

### DIFF
--- a/luxury_tiff_batch_processor.py
+++ b/luxury_tiff_batch_processor.py
@@ -11,16 +11,13 @@ and an optional diffusion glow for an elevated aesthetic.
 from __future__ import annotations
 
 import argparse
-import ast
 import dataclasses
-import dis
-import inspect
 import logging
 import math
 from pathlib import Path
 from typing import Any as _Any
 from typing import Dict as _Dict
-from typing import Iterable, Iterator, List, Optional, Tuple, Union
+from typing import Iterable, Iterator, List, Literal, Optional, Tuple, Union
 
 Any = _Any
 Dict = _Dict
@@ -440,89 +437,9 @@ def ensure_output_path(
     return destination.with_name(new_name)
 
 
-def _expected_unpack_count() -> Optional[int]:
-    frame = inspect.currentframe()
-    if frame is None or frame.f_back is None or frame.f_back.f_back is None:
-        return None
-    caller = frame.f_back.f_back
-    try:
-        source = inspect.getsource(caller.f_code)
-    except (OSError, TypeError):
-        source = None
-    if source is not None:
-        try:
-            module = ast.parse(source)
-        except SyntaxError:
-            module = None
-        else:
-            for node in ast.walk(module):
-                if isinstance(node, ast.Assign):
-                    start = getattr(node, "lineno", -1)
-                    end = getattr(node, "end_lineno", start)
-                    if not (start <= caller.f_lineno <= end):
-                        continue
-                    value = node.value
-                    if isinstance(value, ast.Call):
-                        func = value.func
-                        func_name: Optional[str] = None
-                        if isinstance(func, ast.Name):
-                            func_name = func.id
-                        elif isinstance(func, ast.Attribute):
-                            func_name = func.attr
-                        if func_name == "image_to_float" and node.targets:
-                            target = node.targets[0]
-                            if isinstance(target, (ast.Tuple, ast.List)):
-                                return len(target.elts)
-                            return 1
-
-    try:
-        instructions = list(dis.get_instructions(caller.f_code))
-        target_index: Optional[int] = None
-        for idx, instruction in enumerate(instructions):
-            if instruction.offset > caller.f_lasti:
-                target_index = idx - 1
-                break
-            if instruction.offset == caller.f_lasti:
-                target_index = idx
-                break
-        if target_index is None:
-            return None
-        target_index = max(target_index, 0)
-        for next_instruction in instructions[target_index + 1 :]:
-            if next_instruction.opname in {"CACHE", "EXTENDED_ARG"}:
-                continue
-            if next_instruction.opname == "UNPACK_SEQUENCE":
-                return int(next_instruction.arg)
-            if next_instruction.opname == "UNPACK_EX":
-                arg = int(next_instruction.arg or 0)
-                before = arg & 0xFF
-                after = arg >> 8
-                return before + after
-            break
-        for prev_instruction in reversed(instructions[: target_index + 1]):
-            if prev_instruction.opname in {"CACHE", "EXTENDED_ARG"}:
-                continue
-            if prev_instruction.opname == "UNPACK_SEQUENCE":
-                return int(prev_instruction.arg)
-            if prev_instruction.opname == "UNPACK_EX":
-                arg = int(prev_instruction.arg or 0)
-                before = arg & 0xFF
-                after = arg >> 8
-                return before + after
-            if prev_instruction.opname.startswith("LOAD_") or prev_instruction.opname.startswith("STORE_"):
-                continue
-            if prev_instruction.opname.startswith("PUSH"):
-                continue
-            break
-    except Exception:
-        return None
-    finally:
-        del frame
-    return None
-
-
 def image_to_float(
     image: Image.Image,
+    return_format: Literal["tuple3", "tuple4", "object"] = "object",
 ) -> Union[
     Tuple[np.ndarray, np.dtype, Optional[np.ndarray]],
     Tuple[np.ndarray, np.dtype, Optional[np.ndarray], int],
@@ -607,11 +524,12 @@ def image_to_float(
         float_normalisation=float_norm,
     )
 
-    expected = _expected_unpack_count()
-    if expected == 3:
+    if return_format == "tuple3":
         return result.array, result.dtype, result.alpha
-    if expected == 4:
+    if return_format == "tuple4":
         return result.array, result.dtype, result.alpha, result.base_channels
+    if return_format != "object":
+        raise ValueError(f"Unsupported return_format: {return_format}")
     return result
 
 
@@ -1112,20 +1030,12 @@ def process_single_image(
     with Image.open(source) as image:
         metadata = getattr(image, "tag_v2", None)
         icc_profile = image.info.get("icc_profile") if isinstance(image.info, dict) else None
-        float_result = image_to_float(image)
-        if isinstance(float_result, ImageToFloatResult):
-            arr = float_result.array
-            dtype = float_result.dtype
-            alpha = float_result.alpha
-            base_channels = float_result.base_channels
-            float_norm = float_result.float_normalisation
-        else:
-            if len(float_result) == 3:
-                arr, dtype, alpha = float_result
-                base_channels = arr.shape[2] if arr.ndim == 3 else 1
-            else:
-                arr, dtype, alpha, base_channels = float_result  # type: ignore[misc]
-            float_norm = None
+        float_result = image_to_float(image, return_format="object")
+        arr = float_result.array
+        dtype = float_result.dtype
+        alpha = float_result.alpha
+        base_channels = float_result.base_channels
+        float_norm = float_result.float_normalisation
         adjusted = apply_adjustments(arr, adjustments)
         target = _coerce_resize_target(resize_long_edge, resize_target)
         if target is not None:

--- a/tests/test_float_roundtrip.py
+++ b/tests/test_float_roundtrip.py
@@ -57,7 +57,7 @@ def test_image_to_float_roundtrip_signed_int_image():
     gradient = np.linspace(-5000, 5000, 49, dtype=np.int32).reshape(7, 7)
     image = Image.fromarray(gradient)
 
-    rgb_float, dtype, alpha, _ = image_to_float(image)
+    rgb_float, dtype, alpha, _ = image_to_float(image, return_format="tuple4")
 
     assert dtype == np.int32
     assert alpha is None
@@ -77,15 +77,21 @@ def test_image_to_float_float_dynamic_range_restored():
     image = Image.fromarray(data, mode="F")
 
     result = ltiff.image_to_float(image)
-    if isinstance(result, ltiff.ImageToFloatResult):
-        arr = result.array
-        dtype = result.dtype
-        alpha = result.alpha
-        base_channels = result.base_channels
-        float_norm = result.float_normalisation
+    assert isinstance(result, ltiff.ImageToFloatResult)
+    arr = result.array
+    dtype = result.dtype
+    alpha = result.alpha
+    base_channels = result.base_channels
+    float_norm = result.float_normalisation
+
+    rgb_only, dtype_only, alpha_only = ltiff.image_to_float(image, return_format="tuple3")
+    np.testing.assert_allclose(rgb_only, arr)
+    assert dtype_only == dtype
+    if alpha is None:
+        assert alpha_only is None
     else:
-        arr, dtype, alpha, base_channels = result
-        float_norm = None
+        assert alpha_only is not None
+        np.testing.assert_allclose(alpha_only, alpha)
 
     assert np.issubdtype(dtype, np.floating)
     assert float_norm is not None

--- a/tests/test_luxury_tiff_batch_processor.py
+++ b/tests/test_luxury_tiff_batch_processor.py
@@ -236,7 +236,9 @@ def test_image_roundtrip_uint16_with_alpha():
         warnings.simplefilter("ignore", DeprecationWarning)
         image = Image.fromarray(data, mode="RGBA")
 
-    base_float, base_dtype, alpha, base_channels = ltiff.image_to_float(image)
+    base_float, base_dtype, alpha, base_channels = ltiff.image_to_float(
+        image, return_format="tuple4"
+    )
     assert base_float.dtype == np.float32
     # PIL converts uint16 RGBA to uint8, so base_dtype will be uint8
     assert base_dtype == np.uint8


### PR DESCRIPTION
## Summary
- add an explicit `return_format` parameter to `image_to_float` and remove introspection logic
- update processing code to request the object wrapper explicitly and simplify downstream handling
- refresh unit tests to cover tuple return modes and confirm default object behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e18741675c832ab4bd18a26f2d190a