### PR TITLE
Add optional progress reporting to TIFF batch pipeline

### DIFF
--- a/luxury_tiff_batch_processor.py
+++ b/luxury_tiff_batch_processor.py
@@ -33,6 +33,24 @@ try:  # Optional high-fidelity TIFF writer
 except Exception:  # pragma: no cover - optional dependency
     tifffile = None
 
+try:  # Optional progress bar for batch runs
+    from tqdm import tqdm as _tqdm  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    _tqdm = None
+
+
+def _tqdm_progress(
+    iterable: Iterable[Any], *, total: Optional[int], description: Optional[str]
+) -> Iterable[Any]:
+    """Wrap *iterable* with :mod:`tqdm` if available."""
+
+    if _tqdm is None:  # pragma: no cover - defensive fallback
+        return iterable
+    return _tqdm(iterable, total=total, desc=description, unit="image")
+
+
+_PROGRESS_WRAPPER = _tqdm_progress if _tqdm is not None else None
+
 
 class LuxuryGradeException(RuntimeError):
     """Raised when the processing environment cannot meet luxury standards."""
@@ -119,6 +137,30 @@ __all__ = [
     "run_pipeline",
     "save_image",
 ]
+
+
+def _wrap_with_progress(
+    iterable: Iterable[Any],
+    *,
+    total: Optional[int],
+    description: str,
+    enabled: bool,
+) -> Iterable[Any]:
+    """Return an iterable wrapped with a progress helper when available."""
+
+    if not enabled:
+        return iterable
+
+    helper = _PROGRESS_WRAPPER
+    if helper is None:
+        LOGGER.debug("Progress helper not available; install tqdm for progress reporting.")
+        return iterable
+
+    try:
+        return helper(iterable, total=total, description=description)
+    except Exception:  # pragma: no cover - defensive fallback
+        LOGGER.exception("Progress helper failed; continuing without progress display.")
+        return iterable
 
 
 @dataclasses.dataclass
@@ -339,6 +381,11 @@ def parse_args(argv: Optional[Iterable[str]] = None) -> argparse.Namespace:
         help="Optionally resize the longest image edge to this many pixels while preserving aspect ratio",
     )
     parser.add_argument("--dry-run", action="store_true", help="Preview the work without writing any files")
+    parser.add_argument(
+        "--no-progress",
+        action="store_true",
+        help="Disable progress reporting (useful for minimal or non-interactive environments)",
+    )
 
     # Fine control overrides.
     parser.add_argument("--exposure", type=float, default=None, help="Exposure adjustment in stops")
@@ -1199,7 +1246,14 @@ def run_pipeline(args: argparse.Namespace) -> int:
     LOGGER.info("Found %s image(s) to process", len(images))
     processed = 0
 
-    for image_path in images:
+    progress_iterable = _wrap_with_progress(
+        images,
+        total=len(images),
+        description="Processing images",
+        enabled=not getattr(args, "no_progress", False),
+    )
+
+    for image_path in progress_iterable:
         destination = ensure_output_path(
             input_root,
             output_root,
@@ -1211,6 +1265,8 @@ def run_pipeline(args: argparse.Namespace) -> int:
         if destination.exists() and not args.overwrite and not args.dry_run:
             LOGGER.warning("Skipping %s (exists, use --overwrite to replace)", destination)
             continue
+        if args.dry_run:
+            LOGGER.info("Dry run: would process %s -> %s", image_path, destination)
         process_single_image(
             image_path,
             destination,

--- a/tests/test_luxury_tiff_batch_processor.py
+++ b/tests/test_luxury_tiff_batch_processor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 import sys
+from typing import Any, Dict
 
 import pytest
 
@@ -118,6 +119,64 @@ def test_run_pipeline_dry_run_creates_no_outputs(tmp_path: Path):
 
     assert processed == 0
     assert not any(output_dir.rglob("*.tif"))
+
+
+def _create_sample_image(path: Path) -> None:
+    image = Image.new("RGB", (2, 2), color=(32, 64, 96))
+    image.save(path)
+
+
+def test_run_pipeline_invokes_progress_wrapper(tmp_path: Path, monkeypatch):
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    input_dir.mkdir()
+
+    sample = input_dir / "frame.tif"
+    _create_sample_image(sample)
+
+    args = ltiff.parse_args([str(input_dir), str(output_dir), "--dry-run"])
+
+    calls: Dict[str, Any] = {"called": False, "items": []}
+
+    def stub_progress(iterable, *, total=None, description=None):
+        calls["called"] = True
+        calls["total"] = total
+        calls["description"] = description
+        for item in iterable:
+            calls["items"].append(item)
+            yield item
+
+    monkeypatch.setattr(ltiff, "_PROGRESS_WRAPPER", stub_progress)
+
+    processed = ltiff.run_pipeline(args)
+
+    assert processed == 0
+    assert calls["called"] is True
+    assert calls["total"] == 1
+    assert calls["items"] == [sample]
+    assert "Processing" in (calls["description"] or "")
+
+
+def test_run_pipeline_no_progress_flag(tmp_path: Path, monkeypatch):
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    input_dir.mkdir()
+
+    _create_sample_image(input_dir / "frame.tif")
+
+    args = ltiff.parse_args([str(input_dir), str(output_dir), "--dry-run", "--no-progress"])
+
+    calls = {"called": False}
+
+    def stub_progress(iterable, *, total=None, description=None):
+        calls["called"] = True
+        yield from iterable
+
+    monkeypatch.setattr(ltiff, "_PROGRESS_WRAPPER", stub_progress)
+
+    ltiff.run_pipeline(args)
+
+    assert calls["called"] is False
 
 
 @documents("Filesystem discovery respects operator scope selections")


### PR DESCRIPTION
## Summary
- add an optional tqdm-backed progress wrapper for the TIFF batch processor and expose a --no-progress flag
- log dry-run intents before invoking processing while keeping functional behavior intact
- extend the pipeline tests to cover progress helper invocation and the disable flag

## Testing
- pytest tests/test_luxury_tiff_batch_processor.py

------
https://chatgpt.com/codex/tasks/task_e_68e1874bb6d8832abf080deb63b5a271