### PR TITLE
Import functools for gaussian kernel cache

### DIFF
--- a/luxury_tiff_batch_processor.py
+++ b/luxury_tiff_batch_processor.py
@@ -129,7 +129,6 @@ __all__ = [
     "float_to_dtype_array",
     "gaussian_blur",
     "gaussian_kernel",
-    "gaussian_kernel_cached",
     "image_to_float",
     "main",
     "parse_args",

--- a/luxury_tiff_batch_processor.py
+++ b/luxury_tiff_batch_processor.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import argparse
 import dataclasses
+import functools
 import logging
 import math
 from pathlib import Path
@@ -126,6 +127,9 @@ __all__ = [
     "build_adjustments",
     "collect_images",
     "float_to_dtype_array",
+    "gaussian_blur",
+    "gaussian_kernel",
+    "gaussian_kernel_cached",
     "image_to_float",
     "main",
     "parse_args",
@@ -917,6 +921,7 @@ def apply_saturation(arr: np.ndarray, amount: float) -> np.ndarray:
     return hsv_to_rgb(hsv)
 
 
+@functools.lru_cache(maxsize=32)
 def gaussian_kernel(radius: int, sigma: Optional[float] = None) -> np.ndarray:
     if radius <= 0:
         return np.array([1.0], dtype=np.float32)
@@ -925,6 +930,30 @@ def gaussian_kernel(radius: int, sigma: Optional[float] = None) -> np.ndarray:
     kernel = np.exp(-(ax ** 2) / (2.0 * sigma ** 2))
     kernel /= np.sum(kernel)
     return kernel.astype(np.float32)
+
+
+def gaussian_kernel_cached(radius: int, sigma: Optional[float] = None) -> np.ndarray:
+    """
+    Retrieve a cached 1D Gaussian kernel for the given radius and sigma.
+
+    Parameters
+    ----------
+    radius : int
+        The radius of the kernel. Must be >= 0.
+    sigma : Optional[float]
+        The standard deviation of the Gaussian. If None, a default based on radius is used.
+
+    Returns
+    -------
+    np.ndarray
+        A 1D numpy array containing the Gaussian kernel, normalized to sum to 1.
+
+    Notes
+    -----
+    The returned kernel is cached for each (radius, sigma) combination to improve performance.
+    The kernel must not be mutated; callers should copy it if mutation is required.
+    """
+    return gaussian_kernel(radius, sigma)
 
 
 def separable_convolve(arr: np.ndarray, kernel: np.ndarray, axis: int) -> np.ndarray:
@@ -937,7 +966,7 @@ def separable_convolve(arr: np.ndarray, kernel: np.ndarray, axis: int) -> np.nda
 
 
 def gaussian_blur(arr: np.ndarray, radius: int, sigma: Optional[float] = None) -> np.ndarray:
-    kernel = gaussian_kernel(radius, sigma)
+    kernel = gaussian_kernel_cached(radius, sigma)
     blurred = separable_convolve(arr, kernel, axis=0)
     blurred = separable_convolve(blurred, kernel, axis=1)
     return blurred


### PR DESCRIPTION
## Summary
- import functools in luxury_tiff_batch_processor so the gaussian kernel cache decorator resolves

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e18ce60160832abd3533bd6335ae55