### PR TITLE
Fix missing imports in TIFF batch processor

### DIFF
--- a/luxury_tiff_batch_processor.py
+++ b/luxury_tiff_batch_processor.py
@@ -11,9 +11,11 @@ and an optional diffusion glow for an elevated aesthetic.
 from __future__ import annotations
 
 import argparse
+import contextlib
 import dataclasses
 import logging
 import math
+import uuid
 from pathlib import Path
 from typing import Any as _Any
 from typing import Dict as _Dict


### PR DESCRIPTION
## Summary
- add missing uuid and contextlib imports to luxury_tiff_batch_processor

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e18dac2760832abeb0bb8a94f71d19