### PR TITLE
Add selectable processing profiles for TIFF pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,25 @@ python luxury_tiff_batch_processor.py /path/to/raw_tiffs /path/to/output \
   --preset signature --resize-long-edge 7000 --overwrite
 ```
 
+#### Processing profiles
+
+The TIFF pipeline now offers lightweight processing profiles so you can tune
+fidelity against turnaround directly from the CLI:
+
+- `quality` (default) keeps every adjustment active and preserves the source
+  bit depth and compression choices for maximum latitude.
+- `balanced` retains most tonal work but applies a softened glow/denoise pass
+  and promotes output to 16-bit precision when available so files grade well
+  without the full render cost of the quality profile.
+- `performance` disables the most expensive spatial filters, targets an
+  8-bit export, and switches to JPEG-compressed TIFF output for extremely fast
+  client previews.
+
+Select a profile with `--profile quality|balanced|performance` or set it in a
+configuration file. All presets and manual overrides continue to work, while
+the profile determines how aggressively the high-cost filters run and the
+bit-depth/compression of the exported files.
+
 #### Configuration files
 
 Every command-line flag (other than `--config` itself) can be provided through a

--- a/luxury_tiff_batch_processor/__init__.py
+++ b/luxury_tiff_batch_processor/__init__.py
@@ -34,6 +34,7 @@ from .io_utils import (
     image_to_float,
     save_image,
 )
+from .profiles import DEFAULT_PROFILE_NAME, PROCESSING_PROFILES, ProcessingProfile
 from .pipeline import (
     _PROGRESS_WRAPPER,
     _wrap_with_progress,
@@ -53,6 +54,7 @@ __all__ = [
     "LuxuryGradeException",
     "ProcessingCapabilities",
     "ProcessingContext",
+    "ProcessingProfile",
     "apply_adjustments",
     "build_adjustments",
     "collect_images",
@@ -66,6 +68,8 @@ __all__ = [
     "parse_args",
     "process_image",
     "process_single_image",
+    "PROCESSING_PROFILES",
+    "DEFAULT_PROFILE_NAME",
     "run_pipeline",
     "save_image",
 ]

--- a/luxury_tiff_batch_processor/profiles.py
+++ b/luxury_tiff_batch_processor/profiles.py
@@ -1,0 +1,78 @@
+"""Processing profile definitions for balancing fidelity and throughput."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class ProcessingProfile:
+    """Describe processing trade-offs for a pipeline run."""
+
+    name: str
+    glow_multiplier: float
+    chroma_denoise_multiplier: float
+    target_bit_depth: int | None
+    compression: str | None
+
+    def resolve_glow(self, value: float) -> float:
+        """Return the adjusted glow amount for this profile."""
+
+        return value * self.glow_multiplier
+
+    def resolve_chroma_denoise(self, value: float) -> float:
+        """Return the adjusted chroma denoise amount for this profile."""
+
+        return value * self.chroma_denoise_multiplier
+
+    def target_dtype(self, source_dtype: np.dtype) -> np.dtype:
+        """Return the dtype that should be used for saving results."""
+
+        if self.target_bit_depth is None:
+            return np.dtype(source_dtype)
+
+        if self.target_bit_depth >= 16:
+            return np.dtype(np.uint16)
+
+        return np.dtype(np.uint8)
+
+    def resolve_compression(self, requested: str) -> str:
+        """Return the compression that should be used for this profile."""
+
+        return self.compression or requested
+
+
+DEFAULT_PROFILE_NAME = "quality"
+
+PROCESSING_PROFILES: Dict[str, ProcessingProfile] = {
+    "quality": ProcessingProfile(
+        name="quality",
+        glow_multiplier=1.0,
+        chroma_denoise_multiplier=1.0,
+        target_bit_depth=None,
+        compression=None,
+    ),
+    "balanced": ProcessingProfile(
+        name="balanced",
+        glow_multiplier=0.6,
+        chroma_denoise_multiplier=0.5,
+        target_bit_depth=16,
+        compression=None,
+    ),
+    "performance": ProcessingProfile(
+        name="performance",
+        glow_multiplier=0.0,
+        chroma_denoise_multiplier=0.0,
+        target_bit_depth=8,
+        compression="tiff_jpeg",
+    ),
+}
+
+
+__all__ = [
+    "DEFAULT_PROFILE_NAME",
+    "PROCESSING_PROFILES",
+    "ProcessingProfile",
+]


### PR DESCRIPTION
## Summary
- introduce reusable processing profiles that tune glow, denoise, bit depth, and compression
- expose a --profile option in the CLI and plumb profile handling through the pipeline helpers
- document the trade-offs and cover each profile with smoke tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e1a9a07830832a9e642c11e81b155e