### PR TITLE
Prevent extra options from overriding managed parameters

### DIFF
--- a/coastal_estate_render.py
+++ b/coastal_estate_render.py
@@ -36,6 +36,23 @@ def _load_pipeline_module() -> ModuleType:
     return import_module("lux_render_pipeline")
 
 
+_MANAGED_OPTION_PARAMS: Mapping[str, str] = {
+    "input": "input_image",
+    "out": "output_dir",
+    "prompt": "prompt",
+    "width": "width",
+    "height": "height",
+    "strength": "strength",
+    "gs": "guidance_scale",
+    "w4k": "export_4k",
+    "use_realesrgan": "use_realesrgan",
+    "brand_text": "brand_text",
+    "logo": "brand_logo",
+    "seed": "seed",
+    "neg": "negative_prompt",
+}
+
+
 def render_coastal_estate(
     input_image: str,
     output_dir: str = "./transcended",
@@ -111,8 +128,13 @@ def render_coastal_estate(
         options["neg"] = negative_prompt
 
     if extra_options is not None:
+        conflicting_keys = [key for key in extra_options if key in _MANAGED_OPTION_PARAMS]
+        if conflicting_keys:
+            formatted = ", ".join(sorted(f"'{key}'" for key in conflicting_keys))
+            raise ValueError(f"extra option {formatted} conflicts with managed argument")
+
         for key, value in extra_options.items():
-            if key in options and options[key] is not None:
+            if key in options:
                 raise ValueError(f"extra option '{key}' conflicts with managed argument")
             options[key] = value
 

--- a/tests/test_coastal_estate_render.py
+++ b/tests/test_coastal_estate_render.py
@@ -82,3 +82,14 @@ def test_render_coastal_estate_rejects_conflicting_extra_options(stub_pipeline: 
         cer.render_coastal_estate("estate.tif", extra_options={"input": "other"})
 
     assert "conflicts" in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    "extra_key",
+    ["brand_text", "logo", "seed", "neg"],
+)
+def test_render_coastal_estate_rejects_optional_managed_keys(extra_key: str, stub_pipeline: StubPipeline):
+    with pytest.raises(ValueError) as excinfo:
+        cer.render_coastal_estate("estate.jpg", extra_options={extra_key: "value"})
+
+    assert "conflicts" in str(excinfo.value)


### PR DESCRIPTION
## Summary
- prevent `render_coastal_estate` extra_options from overriding the helper's managed parameters
- add regression tests ensuring optional managed keys (brand_text/logo/seed/neg) are rejected when supplied via extra_options

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e1d5fb2928832aa2c9d1234ec0069f