### PR TITLE
Restore top-level TIFF processor entry point

### DIFF
--- a/luxury_tiff_batch_processor.py
+++ b/luxury_tiff_batch_processor.py
@@ -1,0 +1,15 @@
+"""Backward-compatible shim for the legacy luxury_tiff_batch_processor script.
+
+This thin wrapper preserves the README examples that invoke
+``python luxury_tiff_batch_processor.py`` directly from the repository
+root. The real implementation now lives in the package under
+``luxury_tiff_batch_processor.cli``; importing the wrapper keeps those
+entry points working without duplicating logic.
+"""
+from __future__ import annotations
+
+from luxury_tiff_batch_processor.cli import main
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised via integration test
+    raise SystemExit(main())

--- a/tests/test_luxury_tiff_batch_processor.py
+++ b/tests/test_luxury_tiff_batch_processor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
+import subprocess
 import sys
 from typing import Any, Dict
 
@@ -24,6 +25,21 @@ import luxury_tiff_batch_processor.io_utils as io_utils
 def test_run_pipeline_exposed_in_dunder_all():
     exported = getattr(ltiff, "__all__", ())
     assert "run_pipeline" in exported
+
+
+def test_top_level_script_still_invokable(tmp_path: Path):
+    script = Path(__file__).resolve().parent.parent / "luxury_tiff_batch_processor.py"
+    assert script.exists(), "shim script missing"
+
+    result = subprocess.run(
+        [sys.executable, str(script), "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "Batch enhance TIFF files" in result.stdout
 
 
 def _saturation(rgb: np.ndarray) -> np.ndarray:


### PR DESCRIPTION
## Summary
- add a lightweight shim script so `python luxury_tiff_batch_processor.py` once again launches the CLI
- extend the regression suite to cover the script-based invocation path

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2029bde24832a928cad3d25a2a757