### PR TITLE
Validate roadmap discipline names

### DIFF
--- a/temporal_evolution.py
+++ b/temporal_evolution.py
@@ -100,7 +100,14 @@ class TemporalEvolutionRoadmap:
             raise TypeError("temporal_evolution payload must be a mapping")
 
         disciplines: MutableSequence[EvolutionDiscipline] = []
-        for name, directives in root.items():
+        for raw_name, directives in root.items():
+            if not isinstance(raw_name, str):
+                raise TypeError("Discipline names must be strings")
+
+            name = raw_name.strip()
+            if not name:
+                raise TypeError("Discipline names must not be empty")
+
             normalized = _normalise_directives(name, directives)
             disciplines.append(EvolutionDiscipline(name=name, directives=tuple(normalized)))
 
@@ -135,7 +142,12 @@ def _normalise_directives(name: str, directives: object) -> List[EvolutionDirect
                 raise TypeError(
                     f"Directive mapping for discipline '{name}' must map strings to strings"
                 )
-            result.append(EvolutionDirective(summary.strip(), detail.strip()))
+            stripped_summary = summary.strip()
+            if not stripped_summary:
+                raise TypeError(
+                    f"Directive mapping for discipline '{name}' must include a summary"
+                )
+            result.append(EvolutionDirective(stripped_summary, detail.strip()))
         elif isinstance(entry, str):
             stripped = entry.strip()
             if not stripped:

--- a/tests/test_temporal_evolution.py
+++ b/tests/test_temporal_evolution.py
@@ -56,6 +56,7 @@ def test_from_mapping_parses_nested_temporal_evolution_block() -> None:
         [123],
         [{"Monitor": 10}],
         [{"Monitor": "ok", "Extra": "nope"}],
+        [{"   ": "detail"}],
     ],
 )
 def test_from_mapping_validates_directive_structure(invalid_directives) -> None:
@@ -70,4 +71,15 @@ def test_serialise_round_trip() -> None:
     roadmap = TemporalEvolutionRoadmap.from_mapping(payload)
 
     assert roadmap.serialise() == payload["temporal_evolution"]
+
+
+@pytest.mark.parametrize(
+    "invalid_name",
+    [42, "   "],
+)
+def test_from_mapping_validates_discipline_names(invalid_name) -> None:
+    payload = {"temporal_evolution": {invalid_name: []}}
+
+    with pytest.raises(TypeError):
+        TemporalEvolutionRoadmap.from_mapping(payload)
 


### PR DESCRIPTION
## Summary
- ensure temporal evolution discipline names are non-empty strings and normalise whitespace during parsing
- validate directive mappings include a non-blank summary
- add unit tests covering invalid discipline names and whitespace-only directive summaries

## Testing
- pytest tests/test_temporal_evolution.py

------
https://chatgpt.com/codex/tasks/task_e_68e406d52378832a9f79e66e7a7ade72