### PR TITLE
Add targeted processor for 750 render set

### DIFF
--- a/process_renderings_750.py
+++ b/process_renderings_750.py
@@ -96,17 +96,16 @@ def _apply_temperature(arr: np.ndarray, shift: float) -> np.ndarray:
     arr[..., 0] *= red_scale
     arr[..., 2] *= blue_scale
     return arr
-def _apply_contact_shadows(arr: np.ndarray, strength: float, radius: int) -> None:
+def _apply_contact_shadows(arr: np.ndarray, strength: float, radius: int) -> np.ndarray:
     if strength <= 0:
-        return
+        return arr
 
     lum = _luminance(arr)
     pil_lum = Image.fromarray((np.clip(lum, 0.0, 1.0) * 255).astype(np.uint8))
     blurred = np.asarray(pil_lum.filter(ImageFilter.GaussianBlur(radius=radius)), dtype=np.float32) / 255.0
     ao = np.clip(blurred - lum, 0.0, 1.0)[..., None]
     arr *= 1.0 - strength * ao
-
-
+    return arr
 def _apply_haze(arr: np.ndarray, amount: float) -> np.ndarray:
     if amount <= 0:
         return arr


### PR DESCRIPTION
## Summary
- add a standalone script that grades the five 750px renders with scene-specific recipes
- implement highlight recovery, temperature harmonisation, and micro-contrast adjustments per QA brief
- expose a simple CLI wired to the requested input/output defaults for batch processing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68eac3827168832abe4234944db82824