### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,4 +1,6 @@
 name: Pylint
+permissions:
+  contents: read
 
 on: [push]
 


### PR DESCRIPTION
Potential fix for [https://github.com/RC219805/800-Picacho-Lane-LUTs/security/code-scanning/2](https://github.com/RC219805/800-Picacho-Lane-LUTs/security/code-scanning/2)

To fix the problem, you should add a `permissions` block to restrict the permissions of the GITHUB_TOKEN used in the workflow. The minimal necessary change is to set `permissions: contents: read` at the workflow level (i.e., just below the `name:` or at the root of the YAML), which ensures that all jobs default to the least necessary privileges for reading repository contents. This should be added after the `name:` and before the `on:` keys in the `.github/workflows/pylint.yml` file. No additional methods, imports, or definitions are needed for this fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
