### PR TITLE
Refine CI workflow to front-load linting

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -18,37 +18,27 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v5
-    - name: Cache pip
-      uses: actions/cache@v4
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
+      - uses: actions/checkout@v5
+      # Fast lint gate *before* heavy deps
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'  # or a matrix ['3.11','3.12']
+      - name: Install flake8 only
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8
+      - name: flake8 (errors only)
+        run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
 
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v6
-      with:
-        python-version: "3.10"
-    - name: Free up disk space
-      run: |
-        sudo rm -rf /opt/ghc
-        sudo rm -rf /usr/share/dotnet
-        sudo rm -rf /usr/local/lib/android
-        docker image prune -af
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install flake8
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-        if [ -f setup.py ] || [ -f pyproject.toml ]; then pip install .; fi
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with pytest
-      run: |
-        pytest
+      # Proceed only if lint passes
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt', '**/pyproject.toml') }}
+          restore-keys: ${{ runner.os }}-pip-
+      - name: Install project deps
+        run: |
+          pip install -r requirements.txt
+          pip install -e .
+      - name: Test
+        run: pytest -v


### PR DESCRIPTION
## Summary
- run the flake8 error check before installing the full dependency stack
- update the workflow to use Python 3.12 and cache dependencies after linting
- install the project in editable mode and execute the pytest suite with verbose output

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68efda73df64832a8d1838f352e79f1f