### PR TITLE
Add palette assignment persistence helpers

### DIFF
--- a/board_material_aerial_enhancer.py
+++ b/board_material_aerial_enhancer.py
@@ -19,10 +19,23 @@ from pathlib import Path
 from typing import Callable, Dict, Mapping, MutableMapping, Optional, Sequence
 
 import argparse
-import json
 import math
 import numpy as np
 from PIL import Image, ImageFilter
+
+try:
+    from palette_assignments import load_palette_assignments, save_palette_assignments
+except Exception:  # pragma: no cover - fallback for standalone execution
+    import json
+
+    def load_palette_assignments(path: str | Path, rules: Mapping[str, object] | None = None) -> dict[str, object]:
+        p = Path(path)
+        return {} if not p.exists() else json.loads(p.read_text())
+
+    def save_palette_assignments(assignments: Mapping[str, object], path: str | Path) -> None:
+        p = Path(path)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps(assignments, indent=2, sort_keys=True))
 
 
 @dataclass(frozen=True)

--- a/palette_assignments.py
+++ b/palette_assignments.py
@@ -1,0 +1,74 @@
+"""Utilities for saving and loading aerial material palette assignments."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Iterable, Mapping, MutableMapping
+
+import json
+
+if TYPE_CHECKING:  # pragma: no cover
+    from board_material_aerial_enhancer import MaterialRule
+
+
+_PALETTE_VERSION = "1.0"
+
+
+def _rule_lookup(rules: Iterable["MaterialRule"]) -> Mapping[str, "MaterialRule"]:
+    lookup: MutableMapping[str, "MaterialRule"] = {}
+    for rule in rules:
+        lookup[rule.name] = rule
+    return lookup
+
+
+def load_palette_assignments(
+    path: str | Path,
+    rules: Iterable["MaterialRule"] | Mapping[str, "MaterialRule"] | None = None,
+) -> dict[int, "MaterialRule"]:
+    """Load palette assignments from JSON and map them to material rules."""
+    palette_path = Path(path)
+    if not palette_path.exists():
+        raise FileNotFoundError(palette_path)
+
+    data = json.loads(palette_path.read_text())
+    assignments = data.get("assignments", {})
+    if not isinstance(assignments, dict):
+        raise ValueError("Palette file missing 'assignments' mapping")
+
+    if rules is None:
+        raise ValueError("Material rules are required to load palette assignments")
+
+    if isinstance(rules, Mapping):
+        lookup = {name: rule for name, rule in rules.items()}
+    else:
+        lookup = _rule_lookup(rules)
+
+    resolved: dict[int, "MaterialRule"] = {}
+    for label_str, material_name in assignments.items():
+        try:
+            label = int(label_str)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"Invalid cluster label '{label_str}' in palette file") from exc
+
+        if material_name not in lookup:
+            raise ValueError(f"Unknown material '{material_name}' in palette file")
+        resolved[label] = lookup[material_name]
+
+    return resolved
+
+
+def save_palette_assignments(
+    assignments: Mapping[int, "MaterialRule"],
+    path: str | Path,
+    *,
+    version: str = _PALETTE_VERSION,
+) -> Path:
+    """Persist palette assignments to JSON for reuse."""
+    palette_path = Path(path)
+    palette_path.parent.mkdir(parents=True, exist_ok=True)
+
+    data = {
+        "version": version,
+        "assignments": {str(label): rule.name for label, rule in sorted(assignments.items())},
+    }
+    palette_path.write_text(json.dumps(data, indent=2, sort_keys=True))
+    return palette_path


### PR DESCRIPTION
## Summary
- add a dedicated palette_assignments module to load and save material palettes with validation
- update board_material_aerial_enhancer to import the helpers with a standalone fallback implementation

## Testing
- pytest tests/test_board_material_aerial_enhancer.py

------
https://chatgpt.com/codex/tasks/task_e_68efd97476fc832a87c829f82ace9dca