### PR TITLE
Fix manifest workflow root argument

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -76,9 +76,9 @@ jobs:
           set -euo pipefail
           OUT="montecito_manifest.json"
           if python tools/montecito_manifest.py --help 2>/dev/null | grep -qi -- '--out'; then
-            python tools/montecito_manifest.py --out "$OUT"
+            python tools/montecito_manifest.py . --out "$OUT"
           else
-            python tools/montecito_manifest.py
+            python tools/montecito_manifest.py .
           fi
           if [ ! -f "$OUT" ]; then
             CANDIDATE="$(ls -1t tools/*.json *.json 2>/dev/null | head -n1 || true)"


### PR DESCRIPTION
## Summary
- update the Montecito manifest workflow to pass the repository root positional argument required by the script

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f2be7d08c4832a9af24cbc8e5c4129