### PR TITLE
Potential fix for code scanning alert no. 143: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/optimized-ci.yml
+++ b/.github/workflows/optimized-ci.yml
@@ -1,4 +1,6 @@
 name: Optimized CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/RC219805/800-Picacho-Lane-LUTs/security/code-scanning/143](https://github.com/RC219805/800-Picacho-Lane-LUTs/security/code-scanning/143)

The best way to fix this problem is to explicitly declare the permissions needed for GITHUB_TOKEN at either the workflow root or for each relevant job. For this CI workflow, most steps only require read access to repository contents. Adding a `permissions:` block at the root of the workflow to specify `contents: read` will limit the overall privileges. If any job or step requires additional write access (e.g., for pull request comments or uploading results to GitHub), you could incrementally expand exactly what is needed. In the code shown, the minimal fix is to add the following at the top level (after the `name` field, before or after `on:`):

```yaml
permissions:
  contents: read
```

Change only the .github/workflows/optimized-ci.yml file, adding the `permissions:` block immediately after the workflow name to ensure all jobs inherit these least-privilege permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
