### PR TITLE
Potential fix for code scanning alert no. 25: Unnecessary lambda

### DIFF
--- a/tests/test_golden_hour_courtyard_workflow.py
+++ b/tests/test_golden_hour_courtyard_workflow.py
@@ -101,7 +101,7 @@ def test_process_courtyard_scene_allows_override_removal(monkeypatch, tmp_path):
 
     monkeypatch.setattr(ghc.ltiff, "parse_args", fake_parse_args)
     monkeypatch.setattr(ghc.ltiff, "run_pipeline", lambda args: 0)
-    monkeypatch.setattr(ghc.ltiff, "ProcessingCapabilities", lambda: _SpyCapabilities())
+    monkeypatch.setattr(ghc.ltiff, "ProcessingCapabilities", _SpyCapabilities)
 
     ghc.process_courtyard_scene(tmp_path / "input", overrides={"vibrance": None})
 


### PR DESCRIPTION
Potential fix for [https://github.com/RC219805/800-Picacho-Lane-LUTs/security/code-scanning/25](https://github.com/RC219805/800-Picacho-Lane-LUTs/security/code-scanning/25)

To fix the problem, simply replace the lambda that instantiates `_SpyCapabilities` with the class itself. Specifically, on line 104, change `lambda: _SpyCapabilities()` to `_SpyCapabilities`, so `monkeypatch.setattr(ghc.ltiff, "ProcessingCapabilities", lambda: _SpyCapabilities())` becomes `monkeypatch.setattr(ghc.ltiff, "ProcessingCapabilities", _SpyCapabilities)`. This preserves the existing behavior because Python classes are callable and constructing one with zero arguments is equivalent to calling such a lambda. This change is fully local and preserves all functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
