### PR TITLE
Potential fix for code scanning alert no. 27: Non-standard exception raised in special method

### DIFF
--- a/lux_render_pipeline.py
+++ b/lux_render_pipeline.py
@@ -19,7 +19,7 @@ try:  # keep tests importable without typer
 except Exception:  # pragma: no cover
     class _TyperShim:
         def __getattr__(self, _):
-            raise RuntimeError(
+            raise AttributeError(
                 "CLI features require the optional dependency 'typer'. "
                 "Library functions can be imported without it."
             )


### PR DESCRIPTION
Potential fix for [https://github.com/RC219805/800-Picacho-Lane-LUTs/security/code-scanning/27](https://github.com/RC219805/800-Picacho-Lane-LUTs/security/code-scanning/27)

- In general, methods like `__getattr__` should raise `AttributeError` when the requested attribute can't be provided.
- The best way to fix this issue without altering existing functionality is to change the exception raised from `RuntimeError` to `AttributeError`, keeping the explanatory message so the user still receives a detailed error.
- Edit only the lines inside the `_TyperShim` class where `__getattr__` is defined and the exception is raised (lines 21–25).
- No new methods or external imports are required for this fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
