### PR TITLE
Potential fix for code scanning alert no. 42: Unused global variable

### DIFF
--- a/lux_render_pipeline.py
+++ b/lux_render_pipeline.py
@@ -23,7 +23,6 @@ except Exception:  # pragma: no cover
                 "CLI features require the optional dependency 'typer'. "
                 "Library functions can be imported without it."
             )
-    typer = _TyperShim()  # type: ignore
 # -------------------------------------------------------------------------------------
 
 # --- stdlib ---


### PR DESCRIPTION
Potential fix for [https://github.com/RC219805/800-Picacho-Lane-LUTs/security/code-scanning/42](https://github.com/RC219805/800-Picacho-Lane-LUTs/security/code-scanning/42)

To fix the issue with the unused global variable `typer`, we should either remove its assignment entirely or, if the assignment must remain due to possible side effects, rename it in accordance with unused variable conventions (`_typer_unused` or similar). In this case, the assignment of `typer` serves no purpose, as the CLI command uses a locally imported `_typer` and the rest of the code does not reference the global `typer`. The best fix is to delete the assignment statement (`typer = _TyperShim()  # type: ignore`) from line 26, since there are no side effects on the right-hand side that must be preserved and no uses of `typer`. Only delete the assignment, leaving the class definition and other code unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
