### PR TITLE
Potential fix for code scanning alert no. 74: Empty except

### DIFF
--- a/holographic_node.py
+++ b/holographic_node.py
@@ -83,6 +83,7 @@ class GlobalSystemState:
             try:
                 self._observers.remove(callback)
             except ValueError:
+                # It is not an error if the callback was not subscribed; ignore.
                 pass
 
     @contextmanager


### PR DESCRIPTION
Potential fix for [https://github.com/RC219805/800-Picacho-Lane-LUTs/security/code-scanning/74](https://github.com/RC219805/800-Picacho-Lane-LUTs/security/code-scanning/74)

To fix the problem, we should add an explanatory comment in the except block to indicate why the exception is being suppressed. This makes it clear to future readers and tools that the empty except clause is intentional and expected, not the result of incomplete or careless coding. The functionality should remain unchanged: attempts to unsubscribe a callback not in the list are simply ignored. Only the comment needs to be added, above or in-line with the `pass` statement in the except block within `GlobalSystemState.unsubscribe`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
